### PR TITLE
fixed a few imports of private modules

### DIFF
--- a/scvelo/plotting/utils.py
+++ b/scvelo/plotting/utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import matplotlib.pyplot as pl
 from matplotlib.ticker import MaxNLocator
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-from scanpy.plotting.utils import savefig_or_show, default_palette, adjust_palette
+from scanpy.plotting._utils import savefig_or_show, default_palette, adjust_palette
 from matplotlib.colors import is_color_like
 from scipy.sparse import issparse
 

--- a/scvelo/settings.py
+++ b/scvelo/settings.py
@@ -73,8 +73,8 @@ _rcParams_style = None
 # --------------------------------------------------------------------------------
 
 from matplotlib import rcParams
-from scanpy.plotting.rcmod import set_rcParams_scanpy
-from scanpy.plotting.utils import default_palette
+from scanpy.plotting._rcmod import set_rcParams_scanpy
+from scanpy.plotting._utils import default_palette
 
 
 def set_rcParams_scvelo(fontsize=8, color_map=None, frameon=None):

--- a/scvelo/tools/velocity_pseudotime.py
+++ b/scvelo/tools/velocity_pseudotime.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scanpy.tools.dpt import DPT
+from scanpy.tools._dpt import DPT
 from scipy.sparse import issparse, spdiags, linalg
 
 from .utils import groups_to_bool, scale, strings_to_categoricals


### PR DESCRIPTION
After Scanpy 1.3.7 (will be in either 1.3.8 or 1.4.0), most Scanpy submodules have become private (https://github.com/theislab/scanpy/pull/412).

This fixes the imports of these modules in scvelo and the diff points to the respective locations.

If you want scvelo to be compatible both with Scanpy <=1.3.7 and > 1.3.7, one should catch the imports and resolve them as it was done previously. Even better, but slightly more work, one could write a little `_compat.py` module. Or, one simply requires scanpy>1.3.7; as people are still starting to use scvelo, it might also be a viable option. Some people might get a bit angry though.

Sorry for causing work! It should be a quick fix, though.