### PR TITLE
create new separate figure for quiver_autoscale to protect main figure

### DIFF
--- a/scvelo/plotting/velocity_embedding_grid.py
+++ b/scvelo/plotting/velocity_embedding_grid.py
@@ -167,7 +167,7 @@ def velocity_embedding_grid(adata, basis=None, vkey='velocity', density=None, sm
                          "color": 'grey' if arrow_color is None else arrow_color, "edgecolors": 'k',
                          "headlength": hl/2, "headwidth": hw/2, "headaxislength": hal/2, "linewidth": .2}
         quiver_kwargs.update(kwargs)
-        pl.quiver(X_grid[:, 0], X_grid[:, 1], V_grid[:, 0], V_grid[:, 1], **quiver_kwargs, zorder=3)
+        ax.quiver(X_grid[:, 0], X_grid[:, 1], V_grid[:, 0], V_grid[:, 1], **quiver_kwargs, zorder=3)
 
         if principal_curve:
             curve = adata.uns['principal_curve']['projections']

--- a/scvelo/tools/velocity_embedding.py
+++ b/scvelo/tools/velocity_embedding.py
@@ -11,11 +11,12 @@ import warnings
 def quiver_autoscale(X_emb, V_emb):
     import matplotlib.pyplot as pl
     scale_factor = np.abs(X_emb).max()  # just so that it handles very large values
-    Q = pl.quiver(X_emb[:, 0] / scale_factor, X_emb[:, 1] / scale_factor,
+    fig, ax = pl.subplots()
+    Q = ax.quiver(X_emb[:, 0] / scale_factor, X_emb[:, 1] / scale_factor,
                   V_emb[:, 0], V_emb[:, 1], angles='xy', scale_units='xy', scale=None)
     Q._init()
-    pl.clf()
-    pl.close()
+    fig.clf()
+    #fig.close()
     return Q.scale / scale_factor
 
 

--- a/scvelo/tools/velocity_embedding.py
+++ b/scvelo/tools/velocity_embedding.py
@@ -16,7 +16,7 @@ def quiver_autoscale(X_emb, V_emb):
                   V_emb[:, 0], V_emb[:, 1], angles='xy', scale_units='xy', scale=None)
     Q._init()
     fig.clf()
-
+    pl.close(fig)
     return Q.scale / scale_factor
 
 

--- a/scvelo/tools/velocity_embedding.py
+++ b/scvelo/tools/velocity_embedding.py
@@ -16,7 +16,7 @@ def quiver_autoscale(X_emb, V_emb):
                   V_emb[:, 0], V_emb[:, 1], angles='xy', scale_units='xy', scale=None)
     Q._init()
     fig.clf()
-    #fig.close()
+
     return Q.scale / scale_factor
 
 


### PR DESCRIPTION
Now this is possible:

```PYTHON
gs = plt.GridSpec(1, 2, plt.figure(None, (8, 4), dpi=70))
scv.pl.velocity_embedding(adata, basis='draw_graph_fa', ax=plt.subplot(gs[0]), show=False)
scv.pl.velocity_embedding_stream(adata, basis='draw_graph_fa', ax=plt.subplot(gs[1]), show=False)
scv.pl.velocity_embedding_stream(adata, basis='draw_graph_fa', ax=plt.subplot(gs[2]), show=False)
```
![image](https://user-images.githubusercontent.com/4964309/62195203-c50fb100-b37b-11e9-96c0-f75d1670b861.png)

Before, `scvelo.tools.quiver_autoscale` was creating a new figure that override any previous figure already set resulting in something like this:

```PYTHON
gs = plt.GridSpec(1, 3, plt.figure(None, (12, 4), dpi=70))
scv.pl.velocity_embedding(adata, basis='draw_graph_fa', ax=plt.subplot(gs[0]), show=False)
scv.pl.velocity_embedding_stream(adata, basis='draw_graph_fa', ax=plt.subplot(gs[1]), show=False)
scv.pl.velocity_embedding_grid(adata, basis='draw_graph_fa', ax=plt.subplot(gs[2]), show=False)
``` 
![image](https://user-images.githubusercontent.com/4964309/62190798-832e3d00-b372-11e9-8412-fac37cde2f59.png)
