### PR TITLE
Recast group values as strings in dtype argument when creating np.recarrays in scv.tl.rank_velocity_genes.rank_velocity_genes()

### DIFF
--- a/scvelo/tools/rank_velocity_genes.py
+++ b/scvelo/tools/rank_velocity_genes.py
@@ -233,8 +233,8 @@ def rank_velocity_genes(data, vkey='velocity', n_genes=10, groupby=None, match_w
     if key not in adata.uns.keys(): adata.uns[key] = {}
 
     adata.uns[key] = \
-        {'names': np.rec.fromarrays([n for n in rankings_gene_names], dtype=[(rn, 'U50') for rn in groups]),
-         'scores': np.rec.fromarrays([n.round(2) for n in rankings_gene_scores], dtype=[(rn, 'float32') for rn in groups]),
+        {'names': np.rec.fromarrays([n for n in rankings_gene_names], dtype=[(str(rn), 'U50') for rn in groups]),
+         'scores': np.rec.fromarrays([n.round(2) for n in rankings_gene_scores], dtype=[(str(rn), 'float32') for rn in groups]),
          'params': {'groupby': groupby, 'reference': 'rest', 'method': 't-test_overestim_var', 'use_raw': True}}
 
     logg.info('    finished', time=True, end=' ' if settings.verbosity > 2 else '\n')


### PR DESCRIPTION
Running the current version of `scv.tl.rank_velocity_genes.rank_velocity_genes()` throws the following error:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-57-089e06e333aa> in <module>
----> 1 np.rec.fromarrays([n for n in rankings_gene_names], dtype=[(rn, 'U50') for rn in groups])

~/miniconda3/envs/rtools/lib/python3.7/site-packages/numpy/core/records.py in fromarrays(arrayList, dtype, shape, formats, names, titles, aligned, byteorder)
    616 
    617     if dtype is not None:
--> 618         descr = sb.dtype(dtype)
    619         _names = descr.names
    620     else:

TypeError: data type not understood
```

The error arises from [here](https://github.com/theislab/scvelo/blob/e45a65a8f10c513930a9bd4e9ce58ca09c14e78b/scvelo/tools/rank_velocity_genes.py#L236) and working through the code, I found that Numpy will not tolerate integers as dtype field names (which, at least for me, `groups` is returned from `scv.tl.rank_velocity_genes.select_groups()` as an nd.array of integers).  Explicitly recasting `rn`  as a string solves the issue (again, at least for me).