### PR TITLE
Sym knn

### DIFF
--- a/scvelo/preprocessing/moments.py
+++ b/scvelo/preprocessing/moments.py
@@ -1,7 +1,8 @@
 from .. import settings
 from .. import logging as logg
 from .utils import not_yet_normalized, normalize_per_cell
-from .neighbors import neighbors, get_connectivities, neighbors_to_be_recomputed
+from .neighbors import neighbors, get_connectivities, \
+                       neighbors_to_be_recomputed, neighbors_to_be_recomputed_rep
 
 from scipy.sparse import csr_matrix
 import numpy as np
@@ -45,9 +46,14 @@ def moments(data, n_neighbors=30, n_pcs=None, mode='connectivities', method='uma
         raise ValueError('Could not find spliced / unspliced counts.')
     if any([not_yet_normalized(adata.layers[layer]) for layer in {'spliced', 'unspliced'}]):
         normalize_per_cell(adata)
-    if neighbors_to_be_recomputed(adata, n_neighbors=n_neighbors):
-        if use_rep is None: use_rep = 'X_pca'
-        neighbors(adata, n_neighbors=n_neighbors, use_rep=use_rep, n_pcs=n_pcs, method=method)
+
+    if use_rep is None:
+        if neighbors_to_be_recomputed(adata, n_neighbors=n_neighbors):
+            neighbors(adata, n_neighbors=n_neighbors, use_rep='X_pca', n_pcs=n_pcs, method=method)
+    else:
+        if neighbors_to_be_recomputed_rep(adata, n_neighbors=n_neighbors, use_rep=use_rep):
+            neighbors(adata, n_neighbors=n_neighbors, use_rep=use_rep, n_pcs=n_pcs, method=method)
+
     if mode not in adata.uns['neighbors']:
         raise ValueError('mode can only be \'connectivities\' or \'distances\'')
 

--- a/scvelo/preprocessing/neighbors.py
+++ b/scvelo/preprocessing/neighbors.py
@@ -207,6 +207,23 @@ def neighbors_to_be_recomputed(adata, n_neighbors=None):
         return n_neighs.max() * .1 > n_neighs.min()
 
 
+def neighbors_to_be_recomputed_rep(adata, n_neighbors=None, use_rep=None):
+    # check whether computed KNN graph can be used
+    invalid_neighs = 'neighbors' not in adata.uns.keys() \
+                     or 'distances' not in adata.uns['neighbors'] \
+                     or 'params' not in adata.uns['neighbors'] \
+                     or (n_neighbors is not None and n_neighbors != adata.uns['neighbors']['params']['n_neighbors']) \
+                     or (use_rep is not None and use_rep != adata.uns['neighbors']['params'].get('use_rep', None))
+    if invalid_neighs:
+        return True
+
+    neighbor_params = adata.uns['neighbors']['params']
+    logg.info('using the precomputed KNN graph with {} neighbors computed in basis {!r}'.
+              format(neighbor_params['n_neighbors'], neighbor_params['use_rep']), r=True)
+
+    return False
+
+
 def get_connectivities(adata, mode='connectivities', n_neighbors=None, recurse_neighbors=False):
     if 'neighbors' in adata.uns.keys():
         C = adata.uns['neighbors'][mode]

--- a/scvelo/preprocessing/neighbors.py
+++ b/scvelo/preprocessing/neighbors.py
@@ -108,7 +108,8 @@ def neighbors(adata, n_neighbors=30, n_pcs=None, use_rep=None, knn=True, random_
         logg.switch_verbosity('on', module='scanpy')
 
     adata.uns['neighbors'] = {}
-    adata.uns['neighbors']['params'] = {'n_neighbors': n_neighbors, 'method': method}
+    adata.uns['neighbors']['params'] = {'n_neighbors': n_neighbors, 'method': method,
+                                        'use_rep': use_rep, 'n_pcs': n_pcs}
 
     adata.uns['neighbors']['distances'] = neighbors.distances
     adata.uns['neighbors']['connectivities'] = neighbors.connectivities

--- a/scvelo/preprocessing/neighbors.py
+++ b/scvelo/preprocessing/neighbors.py
@@ -220,7 +220,7 @@ def neighbors_to_be_recomputed_rep(adata, n_neighbors=None, use_rep=None):
 
     neighbor_params = adata.uns['neighbors']['params']
     logg.info('using the precomputed KNN graph with {} neighbors computed in basis {!r}'.
-              format(neighbor_params['n_neighbors'], neighbor_params['use_rep']), r=True)
+              format(neighbor_params['n_neighbors'], neighbor_params.get('use_rep', None)), r=True)
 
     return False
 

--- a/scvelo/tools/__init__.py
+++ b/scvelo/tools/__init__.py
@@ -1,5 +1,5 @@
 from .velocity import velocity, velocity_genes
-from .velocity_graph import velocity_graph
+from .velocity_graph import velocity_graph, velocity_graph_sym
 from .transition_matrix import transition_matrix
 from .velocity_embedding import velocity_embedding
 from .velocity_confidence import velocity_confidence, velocity_confidence_transition, score_robustness

--- a/scvelo/tools/utils.py
+++ b/scvelo/tools/utils.py
@@ -137,7 +137,7 @@ def get_iterative_indices_sym(all_indices, index):
     ixs = all_indices[index, :]
 
     # get rid of padding nans
-    return ixs[np.isfinite(ixs)]  #.astype('int32')
+    return ixs[np.isfinite(ixs)]  # .astype('int32')
 
 
 def groups_to_bool(adata, groups, groupby=None):

--- a/scvelo/tools/utils.py
+++ b/scvelo/tools/utils.py
@@ -137,7 +137,8 @@ def get_iterative_indices_sym(all_indices, index):
     ixs = all_indices[index, :]
 
     # get rid of padding nans
-    return ixs[np.isfinite(ixs)]  # .astype('int32')
+    # indices must be of integer
+    return ixs[np.isfinite(ixs)].astype('int32')
 
 
 def groups_to_bool(adata, groups, groupby=None):

--- a/scvelo/tools/utils.py
+++ b/scvelo/tools/utils.py
@@ -116,6 +116,30 @@ def get_iterative_indices(indices, index, n_recurse_neighbors=2, max_neighs=None
     return indices
 
 
+def get_indices_sym(conn):
+    # utility function that extract indices from connectivity matrix, pads with nans
+    # this is meant to yield the indices from a symmetric KNN graph
+
+    max_per_row = np.max((conn > 0).sum(1))
+    # faster than np.full
+    ixs = np.empty((conn.shape[0], mar_per_row))
+    ixs[:] = np.nan
+
+    for i in range(ixs.shape[0]):
+        cell_indices = conn[i, :].indices
+        ixs[i, :len(cell_indices)] = cell_indices
+
+    return ixs
+
+
+def get_iterative_indices_sym(all_indices, index):
+    # return indices of neighboring cells for a given cell. Works for symmetric KNN graphs.
+    ixs = all_indices[index, :]
+
+    # get rid of padding nans
+    return ixs[np.isfinite(ixs)]  #.astype('int32')
+
+
 def groups_to_bool(adata, groups, groupby=None):
     groups = [groups] if isinstance(groups, str) else groups
     if isinstance(groups, (list, tuple, np.ndarray, np.record)):

--- a/scvelo/tools/utils.py
+++ b/scvelo/tools/utils.py
@@ -122,7 +122,7 @@ def get_indices_sym(conn):
 
     max_per_row = np.max((conn > 0).sum(1))
     # faster than np.full
-    ixs = np.empty((conn.shape[0], mar_per_row))
+    ixs = np.empty((conn.shape[0], max_per_row))
     ixs[:] = np.nan
 
     for i in range(ixs.shape[0]):

--- a/scvelo/tools/velocity_graph.py
+++ b/scvelo/tools/velocity_graph.py
@@ -85,7 +85,7 @@ class VelocityGraph:
                     neighs.compute_neighbors(n_neighbors=n_neighbors, use_rep=basis, n_pcs=10)
                     self.indices = get_indices(dist=neighs.distances)[0]
         else:
-            assert 'neighbors' in adata.uns.keys(), 'For symmetric graph, neighbors must be computed before'
+            assert 'neighbors' in adata.uns.keys(), 'For symmetric graph, neighbors must be computed before.'
             self.indices = get_indices_sym(adata.uns['neighbors']['connectivities'])
 
         self.max_neighs = random_neighbors_at_max
@@ -274,7 +274,7 @@ def velocity_graph_sym(data, vkey='velocity', xkey='Ms', tkey=None, basis=None, 
 
     vgraph = VelocityGraph(adata, vkey=vkey, xkey=xkey, tkey=tkey, basis=basis, n_neighbors=n_neighbors, approx=approx,
                            n_recurse_neighbors=n_recurse_neighbors, random_neighbors_at_max=random_neighbors_at_max,
-                           sqrt_transform=sqrt_transform, gene_subset=gene_subset, report=True)
+                           sqrt_transform=sqrt_transform, gene_subset=gene_subset, report=True, is_sym=True)
 
     if isinstance(basis, str):
         logg.warn(

--- a/scvelo/tools/velocity_graph.py
+++ b/scvelo/tools/velocity_graph.py
@@ -217,8 +217,8 @@ def velocity_graph(data, vkey='velocity', xkey='Ms', tkey=None, basis=None, n_ne
 
 
 def velocity_graph_sym(data, vkey='velocity', xkey='Ms', tkey=None, basis=None, method='umap', n_pcs=None, n_neighbors=None, n_recurse_neighbors=None,
-                   random_neighbors_at_max=None, sqrt_transform=None, variance_stabilization=None, gene_subset=None,
-                   approx=None, copy=False):
+                       random_neighbors_at_max=None, sqrt_transform=None, variance_stabilization=None, gene_subset=None,
+                       approx=None, copy=False):
     """Computes velocity graph based on cosine similarities.
 
     The cosine similarities are computed between velocities and potential cell state transitions.

--- a/scvelo/tools/velocity_graph.py
+++ b/scvelo/tools/velocity_graph.py
@@ -2,7 +2,8 @@ from .. import settings
 from .. import logging as logg
 from ..preprocessing.neighbors import pca, neighbors, neighbors_to_be_recomputed, \
                                       neighbors_to_be_recomputed_rep
-from .utils import cosine_correlation, get_indices, get_indices_sym, get_iterative_indices
+from .utils import cosine_correlation, get_indices, get_indices_sym, get_iterative_indices, \
+                   get_iterative_indices_sym
 from .velocity import velocity
 
 from scipy.sparse import coo_matrix, csr_matrix, issparse


### PR DESCRIPTION
Hey @Marius1311 ,
I've added the symmetric, . I've rebased this branch to use current `scvelo's` master (I've kept this master the same).
In `scvelo/preprocessing/moments.py` you can see that I differientiate which method to call when asking whether to recompute neighbors, based on whether `use_rep` is `None` or not.
It's because in original `neighbors_to_be_recomputed`, the `else` branch also contains the following check `n_neighs.max() * .1 > n_neighs.min() `. I wanted to be most backwards compatible, so I've opted out for this option.
Let me know what you think.