### PR TITLE
Add Paga plot with vkey arguments

### DIFF
--- a/scvelo/plotting/__init__.py
+++ b/scvelo/plotting/__init__.py
@@ -7,4 +7,5 @@ from .velocity_graph import velocity_graph
 from .heatmap import heatmap
 from .utils import hist, plot
 from .simulation import simulation
-from scanpy.plotting import paga, paga_compare, rank_genes_groups
+from scanpy.plotting import paga_compare, rank_genes_groups
+from .paga import paga

--- a/scvelo/plotting/paga.py
+++ b/scvelo/plotting/paga.py
@@ -1,0 +1,142 @@
+from ..tools.utils import groups_to_bool
+from .utils import default_basis, default_size, savefig_or_show, \
+    default_color, make_unique_list, make_unique_valid_list, get_components
+from .scatter import scatter
+from .docs import doc_scatter, doc_params
+
+from matplotlib import rcParams
+import matplotlib.pyplot as pl
+import numpy as np
+
+from scanpy.plotting._tools.paga import paga as scanpy_paga
+
+
+@doc_params(scatter=doc_scatter)
+def paga(adata, basis=None, vkey='velocity', color=None, layer=None, title=None, threshold=None, layout=None, layout_kwds={}, init_pos=None, root=0,
+         labels=None, single_component=False, solid_edges='connectivities', dashed_edges=None, transitions=None,
+         node_size_scale=1, node_size_power=0.5, edge_width_scale=1, min_edge_width=None,
+         max_edge_width=None, arrowsize=30, random_state=0, pos=None, normalize_to_color=False, cmap=None, cax=None,
+         cb_kwds={}, add_pos=True, export_to_gexf=False, plot=True,
+         use_raw=None, size=None, groups=None, components=None,
+         figsize=None, dpi=None, show=True, save=None, ax=None, ncols=None, scatter_flag=None, scatter_kwargs={}, **kwargs):
+    """\
+    PAGA plot on the embedding.
+    Arguments
+    ---------
+    adata: :class:`~anndata.AnnData`
+        Annotated data matrix.
+    x: `str`, `np.ndarray` or `None` (default: `None`)
+        x coordinate
+    y: `str`, `np.ndarray` or `None` (default: `None`)
+        y coordinate
+    vkey: `str` or `None` (default: `None`)
+        Key for annotations of observations/cells or variables/genes.
+    {scatter}
+    Returns
+    -------
+        `matplotlib.Axis` if `show==False`
+    """
+
+    if scatter_flag is None:
+        scatter_flag = ax is None
+    vkey = [key for key in adata.layers.keys() if 'velocity' in key and '_u' not in key] if vkey is 'all' else vkey
+    layers, vkeys, colors = make_unique_list(layer), make_unique_list(vkey), make_unique_list(color, allow_array=True)
+    bases = [default_basis(adata) if basis is None else basis for basis in make_unique_valid_list(adata, basis)]
+
+    paga_kwargs = {'threshold': threshold, 'layout': layout, 'layout_kwds': layout_kwds, 'init_pos': init_pos,
+                   'root': root, 'labels': labels, 'single_component': single_component,
+                   'solid_edges': solid_edges, 'dashed_edges': dashed_edges, 'transitions': transitions,
+                   'node_size_scale': node_size_scale, 'node_size_power': node_size_power,
+                   'edge_width_scale': edge_width_scale, 'min_edge_width': min_edge_width,
+                   'max_edge_width': max_edge_width,
+                   'arrowsize': arrowsize,
+                   'random_state': random_state,
+                   'pos': pos,
+                   'normalize_to_color': normalize_to_color,
+                   'cmap': cmap,
+                   'cax': cax,
+                   'cb_kwds': cb_kwds,
+                   'add_pos': add_pos,
+                   'export_to_gexf': export_to_gexf,
+                   'colors': colors,
+                   'plot': plot}
+
+
+
+    multikey = colors if len(colors) > 1 else layers if len(layers) > 1 \
+        else vkeys if len(vkeys) > 1 else bases if len(bases) > 1 else None
+    if multikey is not None:
+        if title is None:
+            title = list(multikey)
+        elif isinstance(title, (list, tuple)):
+            title *= int(np.ceil(len(multikey) / len(title)))
+        ncols = len(multikey) if ncols is None else min(len(multikey), ncols)
+        nrows = int(np.ceil(len(multikey) / ncols))
+        figsize = rcParams['figure.figsize'] if figsize is None else figsize
+        ax = []
+        for i, gs in enumerate(
+                pl.GridSpec(nrows, ncols, pl.figure(None, (figsize[0] * ncols, figsize[1] * nrows), dpi=dpi))):
+            if i < len(multikey):
+                ax.append(paga(adata, size=size, ax=pl.subplot(gs), scatter_flag=scatter_flag,
+                               basis=bases[i] if len(bases) > 1 else basis,
+                               color=colors[i] if len(colors) > 1 else color,
+                               layer=layers[i] if len(layers) > 1 else layer,
+                               vkey=vkeys[i] if len(vkeys) > 1 else vkey,
+                               title=title[i] if isinstance(title, (list, tuple)) else title,
+                               scatter_kwargs=scatter_kwargs, **paga_kwargs))
+        savefig_or_show(dpi=dpi, save=save, show=show)
+        if not show: return ax
+
+    else:
+
+        color, layer, vkey, basis = colors[0], layers[0], vkeys[0], basis
+        color = default_color(adata) if color is None else color
+        size = default_size(adata) / 2 if size is None else size
+        _adata = adata[
+            groups_to_bool(adata, groups, groupby=color)] if groups is not None and color in adata.obs.keys() else adata
+
+        if basis in adata.var_names and basis is not None:
+            x = adata[:, basis].layers['spliced'] if use_raw else adata[:, basis].layers['Ms']
+            y = adata[:, basis].layers['unspliced'] if use_raw else adata[:, basis].layers['Mu']
+        elif basis is not None:
+            X_emb = adata.obsm['X_' + basis][:, get_components(components, basis)]
+            x, y = X_emb[:, 0], X_emb[:, 1]
+
+        if basis is None and pos is None:
+            pos = None  # default to paga embedding
+        elif pos is None:
+            if 'paga' in adata.uns:
+                # Recompute the centroid positions
+                categories = list(adata.obs[color].cat.categories)
+                pos = np.zeros((len(categories), 2))
+                for ilabel, label in enumerate(categories):
+                    X_emb = adata.obsm['X_' + basis][adata.obs[color] == label, :2]
+                    x_pos, y_pos = np.median(X_emb, axis=0)
+                    pos[ilabel] = [x_pos, y_pos]
+            else:
+                raise ValueError(
+                    'You need to run `scv.tl.paga` first.')
+
+        # Defaults adjustments to PAGA
+        if 'node_size_scale' not in kwargs.keys():
+            kwargs['node_size_scale'] = 3
+        if 'edge_width_scale' not in kwargs.keys():
+            kwargs['edge_width_scale'] = 0.4
+        if 'dashed_edges' not in kwargs.keys():
+            kwargs['dashed_edges'] = 'connectivities'
+        if 'threshold' not in kwargs.keys():
+            kwargs['threshold'] = 0.1
+        if 'max_edge_width' not in kwargs.keys():
+            kwargs['max_edge_width'] = 1
+        if 'transitions' not in kwargs.keys():
+            kwargs['transitions'] = 'transitions_confidence'
+
+        ax = pl.figure(None, figsize, dpi=dpi).gca() if ax is None else ax
+        if scatter_flag and basis is not None:
+            ax = scatter(adata, basis=basis, x=x, y=y, vkey=vkey, layer=layer, color=color, size=size, title=title,
+                         ax=ax, save=None,
+                         zorder=0, show=False, **scatter_kwargs)
+        scanpy_paga(adata, pos=pos, ax=ax, show=False, text_kwds={'alpha': 0}, **kwargs)
+
+        savefig_or_show(dpi=dpi, save=save, show=show)
+        if not show: return ax

--- a/scvelo/tools/__init__.py
+++ b/scvelo/tools/__init__.py
@@ -7,4 +7,5 @@ from .terminal_states import eigs, terminal_states
 from .rank_velocity_genes import velocity_clusters, rank_velocity_genes
 from .velocity_pseudotime import velocity_map, velocity_pseudotime
 from .dynamical_model import DynamicsRecovery, recover_dynamics, align_dynamics, recover_latent_time
-from scanpy.tools import tsne, umap, diffmap, dpt, louvain, paga
+from scanpy.tools import tsne, umap, diffmap, dpt, louvain
+from .paga import paga

--- a/scvelo/tools/paga.py
+++ b/scvelo/tools/paga.py
@@ -1,0 +1,153 @@
+# This is adapted from https://github.com/theislab/paga
+
+from scanpy.tools._paga import PAGA
+import scanpy.logging as sclogg
+import numpy as np
+
+
+class PAGA2(PAGA):
+    def __init__(self, adata, groups, model='v1.2', vkey='velocity'):
+        super().__init__(adata=adata, groups=groups, model=model)
+        self.vkey = vkey
+
+    # overwrite to use flexible vkey
+    def compute_transitions(self):
+        vkey = self.vkey + '_graph'
+        if vkey not in self._adata.uns:
+            if 'velocyto_transitions' in self._adata.uns:
+                self._adata.uns[vkey] = self._adata.uns['velocyto_transitions']
+                sclogg.debug("The key 'velocyto_transitions' has been changed to 'velocity_graph'.")
+            else:
+                raise ValueError(
+                    'The passed AnnData needs to have an `uns` annotation '
+                    "with key 'velocity_graph' - a sparse matrix from RNA velocity."
+                )
+        if self._adata.uns[vkey].shape != (self._adata.n_obs, self._adata.n_obs):
+            raise ValueError(
+                f"The passed 'velocity_graph' have shape {self._adata.uns[vkey].shape} "
+                f"but shoud have shape {(self._adata.n_obs, self._adata.n_obs)}"
+            )
+        # restore this at some point
+        # if 'expected_n_edges_random' not in self._adata.uns['paga']:
+        #     raise ValueError(
+        #         'Before running PAGA with `use_rna_velocity=True`, run it with `False`.')
+        import igraph
+        from scanpy.utils import get_igraph_from_adjacency, get_sparse_from_igraph
+        g = get_igraph_from_adjacency(
+            self._adata.uns[vkey].astype('bool'), directed=True)
+        vc = igraph.VertexClustering(
+            g, membership=self._adata.obs[self._groups_key].cat.codes.values)
+        # set combine_edges to False if you want self loops
+        cg_full = vc.cluster_graph(combine_edges='sum')
+        transitions = get_sparse_from_igraph(cg_full, weight_attr='weight')
+        transitions = transitions - transitions.T
+        transitions_conf = transitions.copy()
+        transitions = transitions.tocoo()
+        total_n = self._neighbors.n_neighbors * np.array(vc.sizes())
+        # total_n_sum = sum(total_n)
+        # expected_n_edges_random = self._adata.uns['paga']['expected_n_edges_random']
+        for i, j, v in zip(transitions.row, transitions.col, transitions.data):
+            # if expected_n_edges_random[i, j] != 0:
+            #     # factor 0.5 because of asymmetry
+            #     reference = 0.5 * expected_n_edges_random[i, j]
+            # else:
+            #     # approximate
+            #     reference = self._neighbors.n_neighbors * total_n[i] * total_n[j] / total_n_sum
+            reference = np.sqrt(total_n[i] * total_n[j])
+            transitions_conf[i, j] = 0 if v < 0 else v / reference
+        transitions_conf.eliminate_zeros()
+        # transpose in order to match convention of stochastic matrices
+        # entry ij means transition from j to i
+        self.transitions_confidence = transitions_conf.T
+
+
+def paga(
+        adata,
+        vkey='velocity',
+        groups=None,
+        model='v1.2',
+        copy=False):
+    """Mapping out the coarse-grained connectivity structures of complex manifolds [Wolf19]_.
+    By quantifying the connectivity of partitions (groups, clusters) of the
+    single-cell graph, partition-based graph abstraction (PAGA) generates a much
+    simpler abstracted graph (*PAGA graph*) of partitions, in which edge weights
+    represent confidence in the presence of connections. By tresholding this
+    confidence in :func:`~scanpy.pl.paga`, a much simpler representation of the
+    manifold data is obtained, which is nonetheless faithful to the topology of
+    the manifold.
+    The confidence should be interpreted as the ratio of the actual versus the
+    expected value of connetions under the null model of randomly connecting
+    partitions. We do not provide a p-value as this null model does not
+    precisely capture what one would consider "connected" in real data, hence it
+    strongly overestimates the expected value. See an extensive discussion of
+    this in [Wolf19]_.
+    .. note::
+        Note that you can use the result of :func:`~scanpy.pl.paga` in
+        :func:`~scanpy.tl.umap` and :func:`~scanpy.tl.draw_graph` via
+        `init_pos='paga'` to get single-cell embeddings that are typically more
+        faithful to the global topology.
+    Parameters
+    ----------
+    adata : :class:`~anndata.AnnData`
+        An annotated data matrix.
+    groups : key for categorical in `adata.obs`, optional (default: 'louvain')
+        You can pass your predefined groups by choosing any categorical
+        annotation of observations (`adata.obs`).
+    vkey: `str` or `None` (default: `None`)
+        Key for annotations of observations/cells or variables/genes.
+    model : {'v1.2', 'v1.0'}, optional (default: 'v1.2')
+        The PAGA connectivity model.
+    copy : `bool`, optional (default: `False`)
+        Copy `adata` before computation and return a copy. Otherwise, perform
+        computation inplace and return `None`.
+    Returns
+    -------
+    **connectivities** : :class:`numpy.ndarray` (adata.uns['connectivities'])
+        The full adjacency matrix of the abstracted graph, weights correspond to
+        confidence in the connectivities of partitions.
+    **connectivities_tree** : :class:`scipy.sparse.csr_matrix` (adata.uns['connectivities_tree'])
+        The adjacency matrix of the tree-like subgraph that best explains
+        the topology.
+    Notes
+    -----
+    Together with a random walk-based distance measure
+    (e.g. :func:`scanpy.tl.dpt`) this generates a partial coordinatization of
+    data useful for exploring and explaining its variation.
+    See Also
+    --------
+    pl.paga
+    pl.paga_path
+    pl.paga_compare
+    """
+    if groups is None:
+        groups = 'clusters' if 'clusters' in adata.obs.keys() else 'louvain' if 'louvain' in adata.obs.keys() else 'grey'
+    if 'neighbors' not in adata.uns:
+        raise ValueError(
+            'You need to run `pp.neighbors` first to compute a neighborhood graph.')
+    adata = adata.copy() if copy else adata
+    from scanpy.utils import sanitize_anndata
+    sanitize_anndata(adata)
+    start = sclogg.info('running PAGA')
+    paga = PAGA2(adata, groups, model=model, vkey=vkey)
+    # only add if not present
+    if 'paga' not in adata.uns:
+        adata.uns['paga'] = {}
+    paga.compute_connectivities()
+    adata.uns['paga']['connectivities'] = paga.connectivities
+    adata.uns['paga']['connectivities_tree'] = paga.connectivities_tree
+    # adata.uns['paga']['expected_n_edges_random'] = paga.expected_n_edges_random
+    adata.uns[groups + '_sizes'] = np.array(paga.ns)
+    paga.compute_transitions()
+    adata.uns['paga']['transitions_confidence'] = paga.transitions_confidence
+    # adata.uns['paga']['transitions_ttest'] = paga.transitions_ttest
+    adata.uns['paga']['groups'] = groups
+    sclogg.info(
+        '    finished',
+        time=start,
+        deep='added\n' + (
+            "    'paga/transitions_confidence', connectivities adjacency (adata.uns)\n"
+            "    'paga/connectivities', connectivities adjacency (adata.uns)\n"
+            "    'paga/connectivities_tree', connectivities subtree (adata.uns)"
+        ),
+    )
+    return adata if copy else None


### PR DESCRIPTION
scv.pl.paga is now the scv version of paga that (if a basis is given) projects the paga graph onto the scatter plot in the embedding.
scv.tl.paga is the scv version of paga in tools that accepts vkey as an argument.