### PR TITLE
Add 0 category before setting values

### DIFF
--- a/scvelo/tools/dynamical_model.py
+++ b/scvelo/tools/dynamical_model.py
@@ -563,6 +563,7 @@ def recover_latent_time(data, vkey='velocity', min_likelihood=.1, min_confidence
 
     roots = np.argsort(t_sum)
     idx_roots = adata.obs[root_key]
+    if 0 not in idx_roots.cat.categories: idx_roots.cat.add_categories(0, inplace=True)
     idx_roots[pd.isnull(idx_roots)] = 0
     if np.any([isinstance(ix, str) for ix in idx_roots]):
         idx_roots = np.array(idx_roots, dtype=bool)
@@ -575,6 +576,7 @@ def recover_latent_time(data, vkey='velocity', min_likelihood=.1, min_confidence
     if end_key in adata.obs.keys():
         fates = np.argsort(t_sum)[::-1]
         idx_fates = adata.obs[end_key]
+        if 0 not in idx_fates.cat.categories: idx_fates.cat.add_categories(0, inplace=True)
         idx_fates[pd.isnull(idx_fates)] = 0
         if np.any([isinstance(ix, str) for ix in idx_fates]):
             idx_fates = np.array(idx_fates, dtype=bool)


### PR DESCRIPTION
When using cellrank roots to compute latent time, pandas threw an error that I must first add the new categories before writing values to the Series object. This PR adds two lines that fix this. (One line for the roots, one for the ends)