### PR TITLE
Fix all comparisons wrongly done with `is`

### DIFF
--- a/scvelo/datasets.py
+++ b/scvelo/datasets.py
@@ -119,7 +119,7 @@ def simulation(n_obs=300, n_vars=None, alpha=None, beta=None, gamma=None, alpha_
 
     def simulate_dynamics(tau, alpha, beta, gamma, u0, s0, noise_model, noise_level):
         ut, st = mRNA(tau, u0, s0, alpha, beta, gamma)
-        if noise_model is 'normal':  # add noise
+        if noise_model == 'normal':  # add noise
             ut += np.random.normal(scale=noise_level * np.percentile(ut, 99) / 10, size=len(ut))
             st += np.random.normal(scale=noise_level * np.percentile(st, 99) / 10, size=len(st))
         ut, st = np.clip(ut, 0, None), np.clip(st, 0, None)
@@ -178,7 +178,7 @@ def simulation(n_obs=300, n_vars=None, alpha=None, beta=None, gamma=None, alpha_
         gamma_i = gamma[i] if isinstance(gamma, (tuple, list, np.ndarray)) else gamma
         tau, alpha_vec, u0_vec, s0_vec = vectorize(t, t_[i], alpha_i, beta_i, gamma_i, alpha_=alpha_, u0=0, s0=0)
 
-        if noise_model is 'gillespie':
+        if noise_model == 'gillespie':
             U[:, i], S[:, i] = simulate_gillespie(alpha_vec, beta, gamma)
         else:
             U[:, i], S[:, i] = simulate_dynamics(tau, alpha_vec, beta_i, gamma_i,

--- a/scvelo/logging.py
+++ b/scvelo/logging.py
@@ -190,14 +190,14 @@ def get_date_string():
 
 def switch_verbosity(mode='on', module=None):
     if module is None: from . import settings
-    elif module is 'scanpy': from scanpy import settings
+    elif module == 'scanpy': from scanpy import settings
     else: exec('from ' + module + ' import settings')
 
-    if mode is 'on' and hasattr(settings, 'tmp_verbosity'):
+    if mode == 'on' and hasattr(settings, 'tmp_verbosity'):
         settings.verbosity = settings.tmp_verbosity
         del settings.tmp_verbosity
 
-    elif mode is 'off':
+    elif mode == 'off':
         settings.tmp_verbosity = settings.verbosity
         settings.verbosity = 0
 

--- a/scvelo/plotting/paga.py
+++ b/scvelo/plotting/paga.py
@@ -39,7 +39,7 @@ def paga(adata, basis=None, vkey='velocity', color=None, layer=None, title=None,
 
     if scatter_flag is None:
         scatter_flag = ax is None
-    vkey = [key for key in adata.layers.keys() if 'velocity' in key and '_u' not in key] if vkey is 'all' else vkey
+    vkey = [key for key in adata.layers.keys() if 'velocity' in key and '_u' not in key] if vkey == 'all' else vkey
     layers, vkeys, colors = make_unique_list(layer), make_unique_list(vkey), make_unique_list(color, allow_array=True)
     bases = [default_basis(adata) if basis is None else basis for basis in make_unique_valid_list(adata, basis)]
 

--- a/scvelo/plotting/scatter.py
+++ b/scvelo/plotting/scatter.py
@@ -57,7 +57,7 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
     # use c & color and cmap & color_map interchangeably, and plot each group separately if groups is 'all'
     if 'c' in kwargs: color = kwargs.pop('c')
     if 'cmap' in kwargs: color_map = kwargs.pop('cmap')
-    if groups is 'all':
+    if groups == 'all':
         if color is None:  color = default_color(adata)
         if is_categorical(adata, color): groups = [[c] for c in adata.obs[color].cat.categories]
 
@@ -97,7 +97,7 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
                 ax.append(scatter(adata, ax=pl.subplot(gs), **multi_kwargs, **scatter_kwargs, **kwargs))
 
         savefig_or_show(dpi=dpi, save=save, show=show)
-        if show is False: return ax
+        if not show: return ax
 
     else:
         # make sure that there are no more lists, e.g. input ['clusters'] becomes 'clusters'
@@ -118,12 +118,12 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
                                  layer=layer[i * (len(layer) > i)], basis=basis, components=components, groups=groups,
                                  xlabel=xlabel, ylabel='expression' if ylabel is None else ylabel, color_map=color_map,
                                  title=y[i * (len(y) > i)] if title is None else title, ax=ax, **scatter_kwargs)
-                if legend_loc is not False and legend_loc is not 'none':
+                if legend_loc and legend_loc != 'none':
                     multikey = [key.replace('Mu', 'unspliced').replace('Ms', 'spliced') for key in multikey]
                     ax.legend(multikey, fontsize=legend_fontsize, loc='best' if legend_loc is None else legend_loc)
 
                 savefig_or_show(dpi=dpi, save=save, show=show)
-                if show is False: return ax
+                if not show: return ax
 
         # actual scatter plot
         else:
@@ -144,7 +144,7 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
             if isinstance(groups, str): groups = [groups]
             if use_raw is None and basis not in adata.var_names:
                 use_raw = layer is None and adata.raw is not None
-            if projection is '3d':
+            if projection == '3d':
                 from mpl_toolkits.mplot3d import Axes3D
             else:
                 projection = None
@@ -186,7 +186,7 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
             elif is_embedding:
                 X_emb = adata.obsm['X_' + basis][:, get_components(components, basis)]
                 x, y = X_emb[:, 0], X_emb[:, 1]
-                z = X_emb[:, 2] if projection is '3d' and X_emb.shape[1] > 2 else None
+                z = X_emb[:, 2] if projection == '3d' and X_emb.shape[1] > 2 else None
 
                 # set legend if categorical color vals in embedding
                 if is_categorical(adata, color):
@@ -301,7 +301,7 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
                 c = np.ravel(c) if len(np.ravel(c)) == len(x) else c
                 if len(c) != len(x):
                     c = 'grey'
-                    if color is not default_color(adata):
+                    if color != default_color(adata):
                         logg.warn('Invalid color key. Using grey instead.')
 
             smp = ax.scatter(x, y, c=c, alpha=alpha, marker='.', zorder=zorder, **kwargs)
@@ -312,11 +312,11 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
             if show_density:
                 plot_density(x, y, show_density, ax=ax)
 
-            if show_linear_fit or show_linear_fit is 0:
-                plot_linfit(x, y, show_linear_fit, legend_loc is not 'none', linecolor, linewidth, fontsize, ax=ax)
+            if show_linear_fit or show_linear_fit == 0:
+                plot_linfit(x, y, show_linear_fit, legend_loc != 'none', linecolor, linewidth, fontsize, ax=ax)
 
             if show_polyfit:
-                plot_polyfit(x, y, show_polyfit, legend_loc is not 'none', linecolor, linewidth, fontsize, ax=ax)
+                plot_polyfit(x, y, show_polyfit, legend_loc != 'none', linecolor, linewidth, fontsize, ax=ax)
 
             if rug:
                 plot_rug(np.ravel(x), color=np.ravel(interpret_colorkey(adata, rug)), ax=ax)

--- a/scvelo/plotting/scatter.py
+++ b/scvelo/plotting/scatter.py
@@ -57,7 +57,7 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
     # use c & color and cmap & color_map interchangeably, and plot each group separately if groups is 'all'
     if 'c' in kwargs: color = kwargs.pop('c')
     if 'cmap' in kwargs: color_map = kwargs.pop('cmap')
-    if groups == 'all':
+    if isinstance(groups, str) and groups == 'all':
         if color is None:  color = default_color(adata)
         if is_categorical(adata, color): groups = [[c] for c in adata.obs[color].cat.categories]
 

--- a/scvelo/plotting/scatter.py
+++ b/scvelo/plotting/scatter.py
@@ -97,7 +97,7 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
                 ax.append(scatter(adata, ax=pl.subplot(gs), **multi_kwargs, **scatter_kwargs, **kwargs))
 
         savefig_or_show(dpi=dpi, save=save, show=show)
-        if not show: return ax
+        if show is False: return ax
 
     else:
         # make sure that there are no more lists, e.g. input ['clusters'] becomes 'clusters'
@@ -118,12 +118,13 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
                                  layer=layer[i * (len(layer) > i)], basis=basis, components=components, groups=groups,
                                  xlabel=xlabel, ylabel='expression' if ylabel is None else ylabel, color_map=color_map,
                                  title=y[i * (len(y) > i)] if title is None else title, ax=ax, **scatter_kwargs)
+                if legend_loc is None: legend_loc = 'best'
                 if legend_loc and legend_loc != 'none':
                     multikey = [key.replace('Mu', 'unspliced').replace('Ms', 'spliced') for key in multikey]
-                    ax.legend(multikey, fontsize=legend_fontsize, loc='best' if legend_loc is None else legend_loc)
+                    ax.legend(multikey, fontsize=legend_fontsize, loc=legend_loc)
 
                 savefig_or_show(dpi=dpi, save=save, show=show)
-                if not show: return ax
+                if show is False: return ax
 
         # actual scatter plot
         else:
@@ -301,7 +302,7 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
                 c = np.ravel(c) if len(np.ravel(c)) == len(x) else c
                 if len(c) != len(x):
                     c = 'grey'
-                    if color != default_color(adata):
+                    if not isinstance(color, str) or color != default_color(adata):
                         logg.warn('Invalid color key. Using grey instead.')
 
             smp = ax.scatter(x, y, c=c, alpha=alpha, marker='.', zorder=zorder, **kwargs)

--- a/scvelo/plotting/simulation.py
+++ b/scvelo/plotting/simulation.py
@@ -55,14 +55,14 @@ def show_full_dynamics(adata, basis, key='true', use_raw=False, linewidth=1, sho
 
     if key != 'true':
         _, ut, st = compute_dynamics(adata, basis, key, extrapolate=False, sort=False, t=show_assignments)
-        if show_assignments != 'only':
+        if not isinstance(show_assignments, str) or show_assignments != 'only':
             ax.scatter(st, ut, color=color, s=1)
         if show_assignments is not None and show_assignments is not False:
             skey, ukey = ('spliced', 'unspliced') if use_raw or 'Ms' not in adata.layers.keys() else ('Ms', 'Mu')
             s, u = make_dense(adata[:, basis].layers[skey]).flatten(), make_dense(adata[:, basis].layers[ukey]).flatten()
             ax.plot(np.array([s, st]), np.array([u, ut]), color='grey', linewidth=.1 * linewidth)
 
-    if show_assignments != 'only':
+    if not isinstance(show_assignments, str) or show_assignments != 'only':
         _, ut, st = compute_dynamics(adata, basis, key, extrapolate=True, t=show_assignments)
         line, = ax.plot(st, ut, color=color, linewidth=linewidth, label=label)
 
@@ -78,7 +78,7 @@ def simulation(adata, var_names='all', legend_loc='upper right', legend_fontsize
                xkey='true_t', ykey=['unspliced', 'spliced', 'alpha'], colors=['darkblue', 'darkgreen', 'grey'], **kwargs):
     from ..tools.utils import make_dense
     from .scatter import scatter
-    var_names = adata.var_names if var_names == 'all' else [name for name in var_names if name in adata.var_names]
+    var_names = adata.var_names if isinstance(var_names, str) and var_names == 'all' else [name for name in var_names if name in adata.var_names]
 
     figsize = rcParams['figure.figsize']
     ncols = len(var_names)

--- a/scvelo/plotting/simulation.py
+++ b/scvelo/plotting/simulation.py
@@ -13,7 +13,7 @@ def get_dynamics(adata, key='fit', extrapolate=False, sorted=False, t=None):
         tmax = t_ + tau_inv(u0_ * 1e-4, u0=u0_, alpha=0, beta=beta)
         t = np.concatenate([np.linspace(0, t_, num=500), t_ + np.linspace(0, tmax, num=500)])
     elif t is None or t is True:
-        t = adata.obs[key + '_t'].values if key is 'true' else adata.layers[key + '_t']
+        t = adata.obs[key + '_t'].values if key == 'true' else adata.layers[key + '_t']
 
     tau, alpha, u0, s0 = vectorize(np.sort(t) if sorted else t, t_, alpha, beta, gamma)
     ut, st = mRNA(tau, u0, s0, alpha, beta, gamma)
@@ -32,7 +32,7 @@ def compute_dynamics(adata, basis, key='true', extrapolate=None, sort=True, t_=N
         u0_offset, s0_offset = 0, 0
 
     if t is None or isinstance(t, bool) or len(t) < adata.n_obs:
-        t = adata.obs[key + '_t'].values if key is 'true' else adata.layers[key + '_t'][:, idx]
+        t = adata.obs[key + '_t'].values if key == 'true' else adata.layers[key + '_t'][:, idx]
 
     if extrapolate:
         u0_ = unspliced(t_, 0, alpha, beta)
@@ -48,21 +48,21 @@ def compute_dynamics(adata, basis, key='true', extrapolate=None, sort=True, t_=N
 
 def show_full_dynamics(adata, basis, key='true', use_raw=False, linewidth=1, show_assignments=None, ax=None):
     if ax is None: ax = pl.gca()
-    color = 'grey' if key is 'true' else 'purple'
-    linewidth = .5 * linewidth if key is 'true' else linewidth
-    label = 'learned dynamics' if key is 'fit' else 'true dynamics'
+    color = 'grey' if key == 'true' else 'purple'
+    linewidth = .5 * linewidth if key == 'true' else linewidth
+    label = 'learned dynamics' if key == 'fit' else 'true dynamics'
     line = None
 
-    if key is not 'true':
+    if key != 'true':
         _, ut, st = compute_dynamics(adata, basis, key, extrapolate=False, sort=False, t=show_assignments)
-        if show_assignments is not 'only':
+        if show_assignments != 'only':
             ax.scatter(st, ut, color=color, s=1)
         if show_assignments is not None and show_assignments is not False:
             skey, ukey = ('spliced', 'unspliced') if use_raw or 'Ms' not in adata.layers.keys() else ('Ms', 'Mu')
             s, u = make_dense(adata[:, basis].layers[skey]).flatten(), make_dense(adata[:, basis].layers[ukey]).flatten()
             ax.plot(np.array([s, st]), np.array([u, ut]), color='grey', linewidth=.1 * linewidth)
 
-    if show_assignments is not 'only':
+    if show_assignments != 'only':
         _, ut, st = compute_dynamics(adata, basis, key, extrapolate=True, t=show_assignments)
         line, = ax.plot(st, ut, color=color, linewidth=linewidth, label=label)
 
@@ -78,7 +78,7 @@ def simulation(adata, var_names='all', legend_loc='upper right', legend_fontsize
                xkey='true_t', ykey=['unspliced', 'spliced', 'alpha'], colors=['darkblue', 'darkgreen', 'grey'], **kwargs):
     from ..tools.utils import make_dense
     from .scatter import scatter
-    var_names = adata.var_names if var_names is 'all' else [name for name in var_names if name in adata.var_names]
+    var_names = adata.var_names if var_names == 'all' else [name for name in var_names if name in adata.var_names]
 
     figsize = rcParams['figure.figsize']
     ncols = len(var_names)
@@ -102,15 +102,15 @@ def simulation(adata, var_names='all', legend_loc='upper right', legend_fontsize
                 y = make_dense(adata.layers[key][:, idx])[idx_sorted]
                 ax = scatter(x=t, y=y, color=colors[j], ax=ax, show=False, **_kwargs)
 
-            if key is 'unspliced':
+            if key == 'unspliced':
                 ax.plot(t, ut, label='unspliced', color=colors[j], linewidth=linewidth)
-            elif key is 'spliced':
+            elif key == 'spliced':
                 ax.plot(t, st, label='spliced', color=colors[j], linewidth=linewidth)
-            elif key is 'alpha':
+            elif key == 'alpha':
                 ax.plot(t, alpha, label='alpha', linestyle='--', color=colors[j], linewidth=linewidth)
 
         pl.xlim(0)
         pl.ylim(0)
-        if legend_loc is not 'none' and i == ncols-1:
+        if legend_loc != 'none' and i == ncols-1:
             pl.legend(loc=legend_loc, fontsize=legend_fontsize)
 

--- a/scvelo/plotting/utils.py
+++ b/scvelo/plotting/utils.py
@@ -645,9 +645,10 @@ def plot_velocity_fits(adata, basis, vkey=None, use_raw=None, linewidth=None, li
         line, fit = show_full_dynamics(adata, basis, 'fit', use_raw, linewidth, show_assignments=show_assignments, ax=ax)
         fits.append(fit); lines.append(line)
 
-    if len(fits) > 0 and (not legend_loc or legend_loc != 'none'):
-        ax.legend(handles=lines, labels=fits, fontsize=legend_fontsize,
-                  loc='lower right' if legend_loc is None else legend_loc)
+    if legend_loc is None:
+        legend_loc = 'lower right'
+    if len(fits) > 0 and legend_loc and legend_loc != 'none':
+        ax.legend(handles=lines, labels=fits, fontsize=legend_fontsize, loc=legend_loc)
 
 
 def plot_density(x, y=None, add_density=True, eval_pts=50, scale=10, alpha=.3, color='grey', ax=None):

--- a/scvelo/plotting/utils.py
+++ b/scvelo/plotting/utils.py
@@ -516,7 +516,7 @@ def rgb_custom_colormap(colors=['royalblue', 'white', 'forestgreen'], alpha=None
     """
     c = []
     for color in colors:
-        if type(color) is str:
+        if isinstance(color, str):
             c.append(to_rgb(cnames[color]))
 
     vals = np.ones((N, 4))
@@ -584,7 +584,7 @@ def plot_linfit(x, y, add_linfit=True, add_legend=True, color=None, linewidth=No
     xnew = np.linspace(np.min(x), np.max(x) * 1.02)
     color = add_linfit if isinstance(add_linfit, str) else color if isinstance(color, str) else 'grey'
 
-    mu_x, mu_y = (0, 0) if add_linfit is 0 else (np.mean(x), np.mean(y))
+    mu_x, mu_y = (0, 0) if add_linfit == 0 else (np.mean(x), np.mean(y))
     slope = (np.mean(x * y) - mu_x * mu_y) / (np.mean(x ** 2) - mu_x ** 2)
     offset = mu_y - slope * mu_x
 
@@ -645,7 +645,7 @@ def plot_velocity_fits(adata, basis, vkey=None, use_raw=None, linewidth=None, li
         line, fit = show_full_dynamics(adata, basis, 'fit', use_raw, linewidth, show_assignments=show_assignments, ax=ax)
         fits.append(fit); lines.append(line)
 
-    if len(fits) > 0 and legend_loc is not False and legend_loc is not 'none':
+    if len(fits) > 0 and (not legend_loc or legend_loc != 'none'):
         ax.legend(handles=lines, labels=fits, fontsize=legend_fontsize,
                   loc='lower right' if legend_loc is None else legend_loc)
 
@@ -830,7 +830,7 @@ def hist(arrays, alpha=.5, bins=50, colors=None, labels=None, hist=None, kde=Non
         bmin, bmax = np.nanpercentile(masked_arrays, perc)
     bins = np.arange(bmin, bmax + (bmax - bmin) / bins, (bmax - bmin) / bins)
 
-    if xscale is 'log':
+    if xscale == 'log':
         bins = bins[bins > 0]
         bins = np.logspace(np.log10(bins[0]), np.log10(bins[-1]), len(bins))
 

--- a/scvelo/plotting/velocity.py
+++ b/scvelo/plotting/velocity.py
@@ -87,7 +87,7 @@ def velocity(adata, var_names=None, basis=None, vkey='velocity', mode=None, fits
 
     (skey, ukey) = ('spliced', 'unspliced') if use_raw or 'Ms' not in adata.layers.keys() else ('Ms', 'Mu')
     layers = [vkey, skey] if layers == 'all' else layers
-    layers = [layer for layer in layers if layer in adata.layers.keys() or layer is 'X']
+    layers = [layer for layer in layers if layer in adata.layers.keys() or layer == 'X']
 
     fits = adata.layers.keys() if fits == 'all' else fits
     fits = [fit for fit in fits if fit + '_gamma' in adata.var.keys()]
@@ -121,7 +121,7 @@ def velocity(adata, var_names=None, basis=None, vkey='velocity', mode=None, fits
         for l, layer in enumerate(layers):
             ax = pl.subplot(gs[v * nplts + l + 1])
             title = 'expression' if layer in ['X', skey] else layer
-            _kwargs = {} if title is 'expression' else kwargs
+            _kwargs = {} if title == 'expression' else kwargs
             cmap = color_map
             if isinstance(color_map, (list, tuple)):
                 cmap = color_map[-1] if layer in ['X', skey] else color_map[0]

--- a/scvelo/plotting/velocity_embedding.py
+++ b/scvelo/plotting/velocity_embedding.py
@@ -43,7 +43,7 @@ def velocity_embedding(adata, basis=None, vkey='velocity', density=None, arrow_s
     """
     #fkeys = ['adata', 'show', 'save', 'groups', 'figsize', 'dpi', 'ncols', 'wspace', 'hspace', 'ax', 'kwargs']
 
-    vkey = [key for key in adata.layers.keys() if 'velocity' in key and '_u' not in key] if vkey is 'all' else vkey
+    vkey = [key for key in adata.layers.keys() if 'velocity' in key and '_u' not in key] if vkey == 'all' else vkey
     layers, vkeys, colors = make_unique_list(layer), make_unique_list(vkey), make_unique_list(color, allow_array=True)
     bases = [default_basis(adata) if basis is None else basis for basis in make_unique_valid_list(adata, basis)]
 

--- a/scvelo/plotting/velocity_embedding_grid.py
+++ b/scvelo/plotting/velocity_embedding_grid.py
@@ -114,7 +114,7 @@ def velocity_embedding_grid(adata, basis=None, vkey='velocity', density=None, sm
         `matplotlib.Axis` if `show==False`
     """
     basis = default_basis(adata) if basis is None else get_basis(adata, basis)
-    vkey = [key for key in adata.layers.keys() if 'velocity' in key and '_u' not in key] if vkey is 'all' else vkey
+    vkey = [key for key in adata.layers.keys() if 'velocity' in key and '_u' not in key] if vkey == 'all' else vkey
     colors, layers, vkeys = make_unique_list(color, allow_array=True), make_unique_list(layer), make_unique_list(vkey)
 
     if V is None:

--- a/scvelo/plotting/velocity_embedding_stream.py
+++ b/scvelo/plotting/velocity_embedding_stream.py
@@ -51,7 +51,7 @@ def velocity_embedding_stream(adata, basis=None, vkey='velocity', density=None, 
         `matplotlib.Axis` if `show==False`
     """
     basis = default_basis(adata) if basis is None else get_basis(adata, basis)
-    vkey = [key for key in adata.layers.keys() if 'velocity' in key and '_u' not in key] if vkey is 'all' else vkey
+    vkey = [key for key in adata.layers.keys() if 'velocity' in key and '_u' not in key] if vkey == 'all' else vkey
     colors, layers, vkeys = make_unique_list(color, allow_array=True), make_unique_list(layer), make_unique_list(vkey)
 
     if V is None:

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -102,7 +102,7 @@ def get_initial_size(adata, layer=None, by_total_size=None):
                        if 'initial_size_' + layer in adata.obs.keys()], axis=0)
     elif layer in adata.layers.keys():
         return np.array(adata.obs['initial_size_' + layer]) if 'initial_size_' + layer in adata.obs.keys() else get_size(adata, layer)
-    elif layer is None or layer is 'X':
+    elif layer is None or layer == 'X':
         return np.array(adata.obs['initial_size']) if 'initial_size' in adata.obs.keys() else get_size(adata)
     else:
         return None
@@ -167,9 +167,9 @@ def filter_genes(data, min_counts=None, min_cells=None, max_counts=None, max_cel
 
     for layer in layers:
 
-        if layer is 'spliced':
+        if layer == 'spliced':
             _min_counts, _min_cells, _max_counts, _max_cells = min_counts, min_cells, max_counts, max_cells
-        elif layer is 'unspliced':
+        elif layer == 'unspliced':
             _min_counts, _min_cells, _max_counts, _max_cells = min_counts_u, min_cells_u, max_counts_u, max_cells_u
         else:  # shared counts/cells
             _min_counts, _min_cells, _max_counts, _max_cells = min_shared_counts, min_shared_cells, None, None
@@ -251,7 +251,7 @@ def filter_genes_dispersion(data, flavor='seurat', min_disp=None, max_disp=None,
     if n_top_genes is not None and adata.n_vars < n_top_genes:
         logg.info('Skip filtering by dispersion since number of variables are less than `n_top_genes`')
     else:
-        if flavor is 'svr':
+        if flavor == 'svr':
             mu = adata.X.mean(0).A1 if issparse(adata.X) else adata.X.mean(0)
             sigma = np.sqrt(adata.X.multiply(adata.X).mean(0).A1 - mu ** 2) if issparse(adata.X) else adata.X.std(0)
             log_mu = np.log2(mu)
@@ -283,9 +283,9 @@ def not_yet_normalized(X):
 
 
 def check_if_valid_dtype(adata, layer='X'):
-    X = adata.X if layer is 'X' else adata.layers[layer]
+    X = adata.X if layer == 'X' else adata.layers[layer]
     if 'int' in X.dtype.name:
-        if layer is 'X':
+        if layer == 'X':
             adata.X = adata.X.astype(np.float32)
         elif layer in adata.layers.keys():
             adata.layers[layer] = adata.layers[layer].astype(np.float32)
@@ -324,14 +324,14 @@ def normalize_per_cell(data, counts_per_cell_after=None, counts_per_cell=None, k
     Returns or updates `adata` with normalized version of the original `adata.X`, depending on `copy`.
     """
     adata = data.copy() if copy else data
-    layers = adata.layers.keys() if layers is 'all' else [layers] if isinstance(layers, str) \
+    layers = adata.layers.keys() if layers == 'all' else [layers] if isinstance(layers, str) \
         else [layer for layer in layers if layer in adata.layers.keys()]
     layers = ['X'] + layers
     modified_layers = []
 
     for layer in layers:
         check_if_valid_dtype(adata, layer)
-        X = adata.X if layer is 'X' else adata.layers[layer]
+        X = adata.X if layer == 'X' else adata.layers[layer]
 
         if not_yet_normalized(X) or enforce:
             counts = counts_per_cell if counts_per_cell is not None \

--- a/scvelo/settings.py
+++ b/scvelo/settings.py
@@ -267,9 +267,9 @@ def set_figure_params(style='scvelo', dpi=100, dpi_save=150, frameon=None, vecto
     if facecolor is not None:
         rcParams['figure.facecolor'] = facecolor
         rcParams['axes.facecolor'] = facecolor
-    if style is 'scvelo':
+    if style == 'scvelo':
         set_rcParams_scvelo(fontsize=fontsize, color_map=color_map, frameon=frameon)
-    elif style is 'scanpy':
+    elif style == 'scanpy':
         set_rcParams_scanpy(fontsize=fontsize, color_map=color_map, frameon=frameon)
     # Overwrite style options if given
     if figsize is not None:

--- a/scvelo/tools/dynamical_model.py
+++ b/scvelo/tools/dynamical_model.py
@@ -264,7 +264,7 @@ def recover_dynamics(data, var_names='velocity_genes', n_top_genes=None, max_ite
         Determined how times are assigned to observations.
         If `projection`, observations are projected onto the model trajectory.
         Else uses an inverse approximating formula.
-    t_max: `float` or `None` (default: `None`)
+    t_max: `float`, `False` or `None` (default: `None`)
         Total range for time assignments.
     fit_scaling: `bool` or `float` or `None` (default: `True`)
         Whether to fit scaling between unspliced and spliced or keep initially given scaling fixed.
@@ -307,7 +307,7 @@ def recover_dynamics(data, var_names='velocity_genes', n_top_genes=None, max_ite
     if isinstance(var_names, str) and var_names not in adata.var_names:
         if var_names in adata.var.keys():
             var_names = adata.var_names[adata.var[var_names].values]
-        elif use_raw or var_names is 'all':
+        elif use_raw or var_names == 'all':
             var_names = adata.var_names
         elif '_genes' in var_names:
             from .velocity import Velocity
@@ -416,7 +416,7 @@ def align_dynamics(data, t_max=None, dm=None, idx=None, mode=None, remove_outlie
     ---------
     data: :class:`~anndata.AnnData`
         Annotated data matrix.
-    t_max: `float` or `None` (default: `None`)
+    t_max: `float`, `False` or `None` (default: `None`)
         Total range for time assignments.
     dm: :class:`~DynamicsRecovery`
         DynamicsRecovery object to perform alignment on.
@@ -453,7 +453,7 @@ def align_dynamics(data, t_max=None, dm=None, idx=None, mode=None, remove_outlie
     if dm is not None:  # newly fitted
         mz[idx] = 1
 
-    if mode is 'align_total_time' and t_max is not False:
+    if mode == 'align_total_time' and t_max is not False:
         T_max = np.max(T[:, idx] * (T[:, idx] < t_[idx]), axis=0) \
                 + np.max((T[:, idx] - t_[idx]) * (T[:, idx] > t_[idx]), axis=0)
 

--- a/scvelo/tools/dynamical_model_utils.py
+++ b/scvelo/tools/dynamical_model_utils.py
@@ -165,7 +165,7 @@ def tau_inv(u, s=None, u0=None, s0=None, alpha=None, beta=None, gamma=None):
 
 
 def assign_tau(u, s, alpha, beta, gamma, t_=None, u0_=None, s0_=None, assignment_mode=None):
-    if assignment_mode is 'projection' and beta < gamma:
+    if assignment_mode == 'projection' and beta < gamma:
         x_obs = np.vstack([u, s]).T
         t0 = tau_inv(np.min(u[s > 0]), u0=u0_, alpha=0, beta=beta)
 
@@ -243,7 +243,7 @@ def compute_divergence(u, s, alpha, beta, gamma, scaling=1, t_=None, u0_=None, s
 
     res, varx = np.array([distx_, distx]), 1  # default vals;
 
-    if noise_model is 'normal':
+    if noise_model == 'normal':
         if var_scale:
             o = np.argmin([distx_, distx], axis=0)
             varu = np.nanvar(distu * o + distu_ + (1 - o), axis=0)
@@ -268,7 +268,7 @@ def compute_divergence(u, s, alpha, beta, gamma, scaling=1, t_=None, u0_=None, s
         res = np.array([connectivities.dot(r) for r in res]) if res.ndim > 2 else connectivities.dot(res.T).T
 
     # compute variances
-    if noise_model is 'chi':
+    if noise_model == 'chi':
         if var_scale:
             o = np.argmin([distx_, distx], axis=0)
             dist = distx * o + distx_ * (1 - o)
@@ -296,58 +296,58 @@ def compute_divergence(u, s, alpha, beta, gamma, scaling=1, t_=None, u0_=None, s
             res[2] += dist_tau * mu_res[1]
             res[3] += dist_tau_ * mu_res[0]
 
-    if mode is 'tau':
+    if mode == 'tau':
         res = [tau, tau_]
 
-    elif mode is 'likelihood':
+    elif mode == 'likelihood':
         res = 1 / (2 * np.pi * np.sqrt(varx)) * np.exp(-.5 * res)
         if normalized: res = normalize(res, min_confidence=min_confidence)
 
-    elif mode is 'nll':
+    elif mode == 'nll':
         res = np.log(2 * np.pi * np.sqrt(varx)) + .5 * res
         if normalized: res = normalize(res, min_confidence=min_confidence)
 
-    elif mode is 'confidence':
+    elif mode == 'confidence':
         res = np.array([res[0], res[1]])
         res = 1 / (2 * np.pi * np.sqrt(varx)) * np.exp(-.5 * res)
         if normalized: res = normalize(res, min_confidence=min_confidence)
         res = np.median(np.max(res, axis=0) - (np.sum(res, axis=0) - np.max(res, axis=0)), axis=1)
 
-    elif mode is 'soft_eval' or mode is 'soft':
+    elif mode in {'soft_eval', 'soft'}:
         res = 1 / (2 * np.pi * np.sqrt(varx)) * np.exp(-.5 * res)
         if normalized: res = normalize(res, min_confidence=min_confidence)
 
         o_, o = res[0], res[1]
         res = np.array([o_, o, ut * o + ut_ * o_, st * o + st_ * o_])
 
-    elif mode is 'hardsoft_eval' or mode is 'hardsoft':
+    elif mode in {'hardsoft_eval', 'hardsoft'}:
         res = 1 / (2 * np.pi * np.sqrt(varx)) * np.exp(-.5 * res)
         if normalized: res = normalize(res, min_confidence=min_confidence)
         o = np.argmax(res, axis=0)
         o_, o = (o == 0) * res[0], (o == 1) * res[1]
         res = np.array([o_, o, ut * o + ut_ * o_, st * o + st_ * o_])
 
-    elif mode is 'hard_eval' or mode is 'hard':
+    elif mode in {'hard_eval', 'hard'}:
         res = 1 / (2 * np.pi * np.sqrt(varx)) * np.exp(-.5 * res)
         if normalized: res = normalize(res, min_confidence=min_confidence)
         o = np.argmax(res, axis=0)
         o_, o = o == 0, o == 1
         res = np.array([o_, o, ut * o + ut_ * o_, st * o + st_ * o_])
 
-    elif mode is 'soft_state':
+    elif mode == 'soft_state':
         res = 1 / (2 * np.pi * np.sqrt(varx)) * np.exp(-.5 * res)
         if normalized: res = normalize(res, min_confidence=min_confidence)
         res = res[1] - res[0]
 
-    elif mode is 'hard_state':
+    elif mode == 'hard_state':
         res = np.argmin(res, axis=0)
 
-    elif mode is 'steady_state':
+    elif mode == 'steady_state':
         res = 1 / (2 * np.pi * np.sqrt(varx)) * np.exp(-.5 * res)
         if normalized: res = normalize(res, min_confidence=min_confidence)
         res = res[2] + res[3]
 
-    elif mode is 'assign_timepoints' or mode is 'time':
+    elif mode in {'assign_timepoints', 'time'}:
         o = np.argmin(res, axis=0)
 
         tau_ *= (o == 0)
@@ -357,9 +357,9 @@ def compute_divergence(u, s, alpha, beta, gamma, scaling=1, t_=None, u0_=None, s
         if 3 in o: o[o == 3] = 0
 
         t = tau * (o == 1) + (tau_ + t_) * (o == 0)
-        res = [t, tau, o] if mode is 'assign_timepoints' else t
+        res = [t, tau, o] if mode == 'assign_timepoints' else t
 
-    elif mode is 'gene_likelihood':
+    elif mode == 'gene_likelihood':
         o = np.argmin(res, axis=0)
 
         tau_ *= (o == 0)
@@ -382,7 +382,7 @@ def compute_divergence(u, s, alpha, beta, gamma, scaling=1, t_=None, u0_=None, s
         ll = - 1 / 2 / n * np.sum(distx) / varx - 1 / 2 * np.log(2 * np.pi * varx)
         res = np.exp(ll)
 
-    elif mode is 'velocity':
+    elif mode == 'velocity':
         res = 1 / (2 * np.pi * np.sqrt(varx)) * np.exp(-.5 * res)
         res = np.array([res[0], res[1], res[2], res[3], 1e-6 * np.ones(res[0].shape)]) if res.ndim > 2 \
             else np.array([res[0], res[1], min_confidence * np.ones(res[0].shape)])
@@ -410,7 +410,7 @@ def compute_divergence(u, s, alpha, beta, gamma, scaling=1, t_=None, u0_=None, s
 
         res = [vt, wt]
 
-    elif mode is 'soft_velocity':
+    elif mode == 'soft_velocity':
         res = 1 / (2 * np.pi * np.sqrt(varx)) * np.exp(-.5 * res)
         if normalized: res = normalize(res, min_confidence=min_confidence)
         o_, o = res[0], res[1]
@@ -521,7 +521,7 @@ class BaseDynamics:
         self.fit_scaling = fit_scaling
         self.fit_steady_states = fit_steady_states
         self.fit_connected_states = fit_connected_states
-        self.connectivities = get_connectivities(adata) if self.fit_connected_states is True else self.fit_connected_states
+        self.connectivities = get_connectivities(adata) if self.fit_connected_states else self.fit_connected_states
         self.high_pars_resolution = high_pars_resolution
 
     def initialize_weights(self):
@@ -641,7 +641,7 @@ class BaseDynamics:
         alpha, beta, gamma, scaling, t_ = self.get_vars(alpha, beta, gamma, scaling, t_, u0_, s0_)
         t, tau, o = self.get_time_assignment(alpha, beta, gamma, scaling, t_, u0_, s0_, t, refit_time, weighted=weighted)
 
-        if weighted is 'dynamical':
+        if weighted == 'dynamical':
             idx = (u > np.max(u) / 3) & (s > np.max(s) / 3)
             if np.sum(idx) > 0: u, s, t = u[idx], s[idx], t[idx]
 
@@ -733,10 +733,10 @@ class BaseDynamics:
         pl.plot(st, ut, color='purple', linestyle='-')
         pl.xlabel('spliced'); pl.ylabel('unspliced');
 
-        if show_assignments is not None and show_assignments is not False:
+        if show_assignments:
             ax.plot(np.array([self.s[idx_sorted], st]),
                     np.array([self.u[idx_sorted], ut]), color='grey', linewidth=.1 * 1)
-        return ax if show is False else None
+        return ax if not show else None
 
     def plot_profile_contour(self, xkey='gamma', ykey='alpha', x_sight=.5, y_sight=.5, num=20, contour_levels=4,
                              fontsize=12, refit_time=None, ax=None, color_map='RdGy', figsize=None, dpi=None,
@@ -771,7 +771,7 @@ class BaseDynamics:
             ax = pl.figure(figsize=(figsize[0], figsize[1]), dpi=dpi).gca()
 
         ax.contourf(x, y, log_zp, levels=num, cmap=color_map, vmin=vmin, vmax=vmax)
-        if contour_levels is not 0:
+        if contour_levels != 0:
             contours = ax.contour(x, y, log_zp, levels=contour_levels, colors='k', linewidths=.5)
             fmt = '%1.1f' if np.isscalar(contour_levels) else '%1.0f'
             ax.clabel(contours, fmt=fmt, inline=True, fontsize=fontsize * .75)

--- a/scvelo/tools/dynamical_model_utils.py
+++ b/scvelo/tools/dynamical_model_utils.py
@@ -521,7 +521,7 @@ class BaseDynamics:
         self.fit_scaling = fit_scaling
         self.fit_steady_states = fit_steady_states
         self.fit_connected_states = fit_connected_states
-        self.connectivities = get_connectivities(adata) if self.fit_connected_states else self.fit_connected_states
+        self.connectivities = get_connectivities(adata) if self.fit_connected_states is True else self.fit_connected_states
         self.high_pars_resolution = high_pars_resolution
 
     def initialize_weights(self):

--- a/scvelo/tools/dynamical_model_utils_deprecated.py
+++ b/scvelo/tools/dynamical_model_utils_deprecated.py
@@ -590,15 +590,15 @@ class DynamicsRecovery(BaseDynamics):
 
     def update_vars(self, r=None, method=None, clip_loss=None):
         if r is None:
-            r = 1e-2 if method is 'adam' else 1e-5
+            r = 1e-2 if method == 'adam' else 1e-5
         if clip_loss is None:
-            clip_loss = False if method is 'adam' else True
+            clip_loss = method != 'adam'
         # if self.weights is None:
         #    self.uniform_weighting(n_regions=5, perc=95)
         t, t_, alpha, beta, gamma, scaling = self.t, self.t_, self.alpha, self.beta, self.gamma, self.scaling
         dalpha, dbeta, dgamma, dalpha_, dtau, dt_ = derivatives(self.u, self.s, t, t_, alpha, beta, gamma, scaling)
 
-        if method is 'adam':
+        if method == 'adam':
             b1, b2, eps = 0.9, 0.999, 1e-8
 
             # update 1st and 2nd order gradient moments
@@ -763,7 +763,7 @@ def recover_dynamics_deprecated(data, var_names='velocity_genes', max_iter=10, l
     if len(var_names) == 0:
         raise ValueError('Variable name not found in var keys.')
 
-    if fit_connected_states is True:
+    if fit_connected_states:
         fit_connected_states = get_connectivities(adata)
 
     alpha, beta, gamma, t_, scaling = read_pars(adata)

--- a/scvelo/tools/rank_velocity_genes.py
+++ b/scvelo/tools/rank_velocity_genes.py
@@ -220,7 +220,7 @@ def rank_velocity_genes(data, vkey='velocity', n_genes=10, groupby=None, match_w
     """
     adata = data.copy() if copy else data
 
-    if groupby is None or groupby is 'velocity_clusters':
+    if groupby is None or groupby == 'velocity_clusters':
         velocity_clusters(adata, vkey=vkey, match_with=match_with, resolution=resolution, min_likelihood=min_likelihood)
         groupby = vkey + '_clusters'
 

--- a/scvelo/tools/utils.py
+++ b/scvelo/tools/utils.py
@@ -157,7 +157,7 @@ def groups_to_bool(adata, groups, groupby=None):
 
 
 def most_common_in_list(lst):
-    lst = [item for item in lst if item is not np.nan and item is not 'nan']
+    lst = [item for item in lst if item is not np.nan and item != 'nan']
     lst = list(lst)
     return max(set(lst), key=lst.count)
 
@@ -342,7 +342,7 @@ def get_duplicates(array):
 
 def corrcoef(x, y, mode='pearsons'):
     from scipy.stats import pearsonr, spearmanr
-    corr, _ = spearmanr(x, y) if mode is 'spearmans' else pearsonr(x, y)
+    corr, _ = spearmanr(x, y) if mode == 'spearmans' else pearsonr(x, y)
     return corr
 
 

--- a/scvelo/tools/velocity_graph.py
+++ b/scvelo/tools/velocity_graph.py
@@ -56,7 +56,7 @@ class VelocityGraph:
             self.X = np.array(X, dtype=np.float32)
             self.V = np.array(V, dtype=np.float32)
 
-        self.sqrt_transform = (adata.uns[vkey + '_settings']['mode'] is 'stochastic') if sqrt_transform is None else sqrt_transform
+        self.sqrt_transform = (adata.uns[vkey + '_settings']['mode'] == 'stochastic') if sqrt_transform is None else sqrt_transform
         if self.sqrt_transform: self.V = np.sqrt(np.abs(self.V)) * np.sign(self.V)
         self.V -= np.nanmean(self.V, axis=1)[:, None]
 


### PR DESCRIPTION
Fixes #151.

Basically I searched all occurences of this regex `\wis\w(?!(not\w)?(None|np\.nan))`. Mostly for things like the *really* widespread `if mode is 'something'` or 'if number is 0' or `if show is False: return ax` (the last one is the only one that’s not wrong, just overeager).

I skipped the `is (not) True/False` ones that look right, e.g. because you did:

```py
if not thing:
    if thing is True: special_case()
    common_case(thing)
```

Please check all those spots anyway, I might have made an incorrect assumption somewhere.