### PR TITLE
Scatter z-order

### DIFF
--- a/scvelo/plotting/scatter.py
+++ b/scvelo/plotting/scatter.py
@@ -58,7 +58,7 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
     if 'c' in kwargs: color = kwargs.pop('c')
     if 'cmap' in kwargs: color_map = kwargs.pop('cmap')
 
-    cols = [color] if isinstance(color, str) else color
+    cols = to_list(color)
     if groups is None:
         if is_categorical(adata, cols[0]):
             groups = [c for col in cols

--- a/scvelo/plotting/scatter.py
+++ b/scvelo/plotting/scatter.py
@@ -57,9 +57,13 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
     # use c & color and cmap & color_map interchangeably, and plot each group separately if groups is 'all'
     if 'c' in kwargs: color = kwargs.pop('c')
     if 'cmap' in kwargs: color_map = kwargs.pop('cmap')
-    if isinstance(groups, str) and groups == 'all':
+
+    c = color[0] if not isinstance(color, str) else color
+    if groups is None:
+        if is_categorical(adata, c): groups = [c for c in adata.obs[c].cat.categories]
+    elif isinstance(groups, str) and groups == 'all':
         if color is None:  color = default_color(adata)
-        if is_categorical(adata, color): groups = [[c] for c in adata.obs[color].cat.categories]
+        if is_categorical(adata, c): groups = [[c] for c in adata.obs[c].cat.categories]
 
     # create list of each mkey (won't be needed in the future) and check if all bases are valid.
     color, layer, x, y, components = to_list(color), to_list(layer), to_list(x), to_list(y), to_list(components)

--- a/scvelo/plotting/scatter.py
+++ b/scvelo/plotting/scatter.py
@@ -58,12 +58,14 @@ def scatter(adata=None, x=None, y=None, basis=None, vkey=None, color=None, use_r
     if 'c' in kwargs: color = kwargs.pop('c')
     if 'cmap' in kwargs: color_map = kwargs.pop('cmap')
 
-    c = color[0] if not isinstance(color, str) else color
+    cols = [color] if isinstance(color, str) else color
     if groups is None:
-        if is_categorical(adata, c): groups = [c for c in adata.obs[c].cat.categories]
+        if is_categorical(adata, cols[0]):
+            groups = [c for col in cols
+                      for c in (adata.obs[col].cat.categories if is_categorical(adata, col) else [])]
     elif isinstance(groups, str) and groups == 'all':
         if color is None:  color = default_color(adata)
-        if is_categorical(adata, c): groups = [[c] for c in adata.obs[c].cat.categories]
+        if is_categorical(adata, cols[0]): groups = [[c] for c in adata.obs[cols[0]].cat.categories]
 
     # create list of each mkey (won't be needed in the future) and check if all bases are valid.
     color, layer, x, y, components = to_list(color), to_list(layer), to_list(x), to_list(y), to_list(components)


### PR DESCRIPTION
Hey @VolkerBergen ,
currently, the z-order for scatterplot is not working as expected, see below. The least invasive workaround is to set `groups` to be not `None` and that's what I in essence do.
![old](https://user-images.githubusercontent.com/46717574/75186360-116f7380-5748-11ea-996c-048ee84d3939.png)
After the fix, the dots are correctly being displayed. Also the `groups='all'` now works if `color` is categorical in `adata.obs`.
![new](https://user-images.githubusercontent.com/46717574/75186530-57c4d280-5748-11ea-8be2-a75f91752d9b.png)

