### PR TITLE
Feat/pre commit hook

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Migrate code style to Black
+630039c63be21d55ffc97928416091bd013487d8
+4f0d756c282ebe01b6154ab0ff601ad92673d58a

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,0 @@
-# Migrate code style to Black
-630039c63be21d55ffc97928416091bd013487d8
-4f0d756c282ebe01b6154ab0ff601ad92673d58a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,19 @@ python:
 install:
   - pip install docutils
   - pip install -e .
+  - pip install black>=19.10b0
 
 env: MPLBACKEND=Agg
 
-script:
-  - pytest
-  - rst2html.py --halt=2 README.rst >/dev/null
+jobs:
+  allow_failures:
+    env:
+      - CAN_FAIL=true
+  include:
+    - stage: "linting"
+      env: CAN_FAIL=true
+      script: black --check .
+    - stage: "test"
+      script:
+        - pytest
+        - rst2html.py --halt=2 README.rst >/dev/null

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -29,6 +29,11 @@ or::
 ``-e`` is short for ``--editable`` and links the package to the original cloned
 location such that pulled changes are also reflected in the environment.
 
+To contribute to scVelo install the latest packages required for development and the pre-commit hooks::
+
+    pip install -r requirement-dev.txt
+    pre-commit install
+
 
 Dependencies
 ^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
 [build-system]
 requires = ['setuptools', 'setuptools_scm', 'wheel']
 build-backend = 'setuptools.build_meta'
+
+[tool.black]
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+-r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 -r requirements.txt
 
-black>=19.10b0
+-e .
+
+black==19.10b0
 pre-commit==2.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,4 @@
 -r requirements.txt
+
+black>=19.10b0
+pre-commit==2.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,7 @@
 -r requirements.txt
 
+git+https://github.com/theislab/scvelo
+
+#TODO: Check if older versions are compatible as well.
 black>=19.10b0
-pre-commit==2.5.1
+pre-commit>=2.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,4 @@
 -r requirements.txt
 
-git+https://github.com/theislab/scvelo
-
-#TODO: Check if older versions are compatible as well.
 black>=19.10b0
-pre-commit>=2.5.1
+pre-commit==2.5.1


### PR DESCRIPTION
Add pre-commit hooks including code style `black` for now. In the future, further linting steps, such as flake8 for example, can be added.

This is mostly the same as #218 but does not include any code refactoring with `black`.

To ensure a meaningful output of git blame, the file `.git-blame-ignore-revs` is added. Running `git blame SOME_FILE.py --ignore-revs-file .git-blame-ignore-revs` will exclude any commits listed (specified by commit identifier) in `.git-blame-ignore-revs`. Thus, refactoring commit which do not add any new content can be excluded. This requires a Git version of at least 2.23.

FYI @VolkerBergen: I added two of your recent refactoring commits I found.

The CI has been updated to include two stages: `linting` and `test`. The former checks if the black code style is met and is currently allowed to fail to not slow down rapid development. This should be changed in the future once the entire code has been refactored to code style `black`.