### PR TITLE
Fix and refactor / Neighbors

### DIFF
--- a/scvelo/preprocessing/neighbors.py
+++ b/scvelo/preprocessing/neighbors.py
@@ -294,15 +294,7 @@ def get_neighs(adata, mode="distances"):
 
 
 def get_n_neighs(adata):
-    return (
-        adata.uns["neighbors"]["params"]["n_neighbors"]
-        if (
-            "neighbors" in adata.uns.keys()
-            and "params" in adata.uns["neighbors"]
-            and "n_neighbors" in adata.uns["neighbors"]["params"]
-        )
-        else 0
-    )
+    return adata.uns.get("neighbors", {}).get("params", {}).get("n_neighbors", 0)
 
 
 def verify_neighbors(adata):

--- a/scvelo/preprocessing/neighbors.py
+++ b/scvelo/preprocessing/neighbors.py
@@ -177,6 +177,7 @@ def neighbors(
         "method": method,
         "metric": metric,
         "n_pcs": n_pcs,
+        "use_rep": use_rep,
     }
 
     logg.info("    finished", time=True, end=" " if settings.verbosity > 2 else "\n")


### PR DESCRIPTION
## Changes

* Add the used representation to calculate the neighbor graph to `adata.uns["neighbors"]["params"]` in the function `neighbors`.

* Refactor the function `get_n_neighs` into a more concise and pythonic way.

## Related issues:
Closes #271. Closes #272.