### PR TITLE
Fix simulation

### DIFF
--- a/scvelo/datasets.py
+++ b/scvelo/datasets.py
@@ -233,7 +233,7 @@ def simulation(
 
     noise_level = cycle(noise_level, len(switches) if n_vars is None else n_vars)
 
-    n_vars = max(len(switches), len(noise_level)) if n_vars is None else n_vars
+    n_vars = min(len(switches), len(noise_level)) if n_vars is None else n_vars
     U = np.zeros(shape=(len(t), n_vars))
     S = np.zeros(shape=(len(t), n_vars))
 


### PR DESCRIPTION
## Bug fixes

* Fixes `simulation` to work when specifying multiple noise levels and time switches but no number of variables.

## Related issues

Closes #327.