### PR TITLE
Fix umap-learn version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scanpy>=1.5           # adapt to new anndata attributes (v1.5)
 loompy>=2.0.12        # introduced sparsity support (v2.0.12)
 
 # for computing neighbor graph connectivities
-umap-learn>=0.3.10    # removed numba warnings (v0.3.10)
+umap-learn>=0.3.10, <0.5    # removed numba warnings (v0.3.10)
 
 # standard requirements for data analysis
 numpy>=1.17           # extension/speedup in .nan_to_num, .exp (v1.17)


### PR DESCRIPTION
## Changes

* Use umap-learn version priot to `0.5`.

## Related issues

* Closes #329. Related to #326, #328.