### PR TITLE
Pin numba version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ loompy>=2.0.12        # introduced sparsity support (v2.0.12)
 umap-learn>=0.3.10, <0.5    # removed numba warnings (v0.3.10)
 
 # standard requirements for data analysis
+numba>=0.41.0,<0.53.0
 numpy>=1.17           # extension/speedup in .nan_to_num, .exp (v1.17)
 scipy>=1.4.1          # introduced PCA sparsity support (v1.4)
 pandas>=0.23          # merging/sorting extensions (v0.23)


### PR DESCRIPTION
## Changes

* numba version is set to `>=0.41.0` (from scanpy) and `<0.53.0`.

## Related issues

Closes #387.