### PR TITLE
Move functions to core/_anndata.py

### DIFF
--- a/scvelo/__init__.py
+++ b/scvelo/__init__.py
@@ -1,10 +1,12 @@
 """scvelo - RNA velocity generalized through dynamical modeling"""
+from anndata import AnnData
 from scanpy import read, read_loom
 
+from scvelo.core import get_df
 from . import datasets, logging, pl, pp, settings, tl, utils
 from .plotting.gridspec import GridSpec
 from .preprocessing.neighbors import Neighbors
-from .read_load import AnnData, DataFrame, get_df, load, read_csv
+from .read_load import DataFrame, load, read_csv
 from .settings import set_figure_params
 from .tools.run import run_all, test
 from .tools.utils import round

--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -10,6 +10,7 @@ from ._anndata import (
     merge,
     set_initial_size,
     set_modality,
+    show_proportions,
 )
 from ._arithmetic import clipped_log, invert, prod_sum, sum
 from ._linear_models import LinearRegression
@@ -36,6 +37,7 @@ __all__ = [
     "prod_sum",
     "set_initial_size",
     "set_modality",
+    "show_proportions",
     "SplicingDynamics",
     "sum",
 ]

--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -4,6 +4,7 @@ from ._anndata import (
     get_size,
     make_dense,
     make_sparse,
+    set_initial_size,
     set_modality,
 )
 from ._arithmetic import clipped_log, invert, prod_sum, sum
@@ -25,6 +26,7 @@ __all__ = [
     "make_sparse",
     "parallelize",
     "prod_sum",
+    "set_initial_size",
     "set_modality",
     "SplicingDynamics",
     "sum",

--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -1,5 +1,6 @@
 from ._anndata import (
     clean_obs_names,
+    cleanup,
     get_initial_size,
     get_modality,
     get_size,
@@ -16,6 +17,7 @@ from ._parallelize import get_n_jobs, parallelize
 
 __all__ = [
     "clean_obs_names",
+    "cleanup",
     "clipped_log",
     "get_initial_size",
     "get_modality",

--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -1,6 +1,7 @@
 from ._anndata import (
     clean_obs_names,
     cleanup,
+    get_df,
     get_initial_size,
     get_modality,
     get_size,
@@ -20,6 +21,7 @@ __all__ = [
     "clean_obs_names",
     "cleanup",
     "clipped_log",
+    "get_df",
     "get_initial_size",
     "get_modality",
     "get_n_jobs",

--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -6,6 +6,7 @@ from ._anndata import (
     get_size,
     make_dense,
     make_sparse,
+    merge,
     set_initial_size,
     set_modality,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "LinearRegression",
     "make_dense",
     "make_sparse",
+    "merge",
     "parallelize",
     "prod_sum",
     "set_initial_size",

--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -1,4 +1,5 @@
 from ._anndata import (
+    clean_obs_names,
     get_initial_size,
     get_modality,
     get_size,
@@ -14,6 +15,7 @@ from ._models import SplicingDynamics
 from ._parallelize import get_n_jobs, parallelize
 
 __all__ = [
+    "clean_obs_names",
     "clipped_log",
     "get_initial_size",
     "get_modality",

--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -1,4 +1,11 @@
-from ._anndata import get_modality, get_size, make_dense, make_sparse, set_modality
+from ._anndata import (
+    get_initial_size,
+    get_modality,
+    get_size,
+    make_dense,
+    make_sparse,
+    set_modality,
+)
 from ._arithmetic import clipped_log, invert, prod_sum, sum
 from ._linear_models import LinearRegression
 from ._metrics import l2_norm
@@ -7,6 +14,7 @@ from ._parallelize import get_n_jobs, parallelize
 
 __all__ = [
     "clipped_log",
+    "get_initial_size",
     "get_modality",
     "get_n_jobs",
     "get_size",

--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -1,4 +1,4 @@
-from ._anndata import get_modality, make_dense, make_sparse, set_modality
+from ._anndata import get_modality, get_size, make_dense, make_sparse, set_modality
 from ._arithmetic import clipped_log, invert, prod_sum, sum
 from ._linear_models import LinearRegression
 from ._metrics import l2_norm
@@ -9,6 +9,7 @@ __all__ = [
     "clipped_log",
     "get_modality",
     "get_n_jobs",
+    "get_size",
     "invert",
     "l2_norm",
     "LinearRegression",

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 from numpy import ndarray
 from pandas import DataFrame
+from pandas.api.types import is_categorical_dtype
 from scipy.sparse import csr_matrix, issparse, spmatrix
 
 from anndata import AnnData
@@ -130,6 +131,173 @@ def cleanup(data, clean="layers", keep=None, copy=False):
                 del getattr(adata, ann)[value]
 
     return adata if copy else None
+
+
+def get_df(
+    data,
+    keys=None,
+    layer=None,
+    index=None,
+    columns=None,
+    sort_values=None,
+    dropna="all",
+    precision=None,
+):
+    """Get dataframe for a specified adata key.
+
+    Return values for specified key
+    (in obs, var, obsm, varm, obsp, varp, uns, or layers) as a dataframe.
+
+    Arguments
+    ------
+    adata
+        AnnData object or a numpy array to get values from.
+    keys
+        Keys from `.var_names`, `.obs_names`, `.var`, `.obs`,
+        `.obsm`, `.varm`, `.obsp`, `.varp`, `.uns`, or `.layers`.
+    layer
+        Layer of `adata` to use as expression values.
+    index
+        List to set as index.
+    columns
+        List to set as columns names.
+    sort_values
+        Wether to sort values by first column (sort_values=True) or a specified column.
+    dropna
+        Drop columns/rows that contain NaNs in all ('all') or in any entry ('any').
+    precision
+        Set precision for pandas dataframe.
+
+    Returns
+    -------
+    A dataframe.
+    """
+    if precision is not None:
+        pd.set_option("precision", precision)
+
+    if isinstance(data, AnnData):
+        keys, keys_split = (
+            keys.split("*") if isinstance(keys, str) and "*" in keys else (keys, None)
+        )
+        keys, key_add = (
+            keys.split("/") if isinstance(keys, str) and "/" in keys else (keys, None)
+        )
+        keys = [keys] if isinstance(keys, str) else keys
+        key = keys[0]
+
+        s_keys = ["obs", "var", "obsm", "varm", "uns", "layers"]
+        d_keys = [
+            data.obs.keys(),
+            data.var.keys(),
+            data.obsm.keys(),
+            data.varm.keys(),
+            data.uns.keys(),
+            data.layers.keys(),
+        ]
+
+        if hasattr(data, "obsp") and hasattr(data, "varp"):
+            s_keys.extend(["obsp", "varp"])
+            d_keys.extend([data.obsp.keys(), data.varp.keys()])
+
+        if keys is None:
+            df = data.to_df()
+        elif key in data.var_names:
+            df = obs_df(data, keys, layer=layer)
+        elif key in data.obs_names:
+            df = var_df(data, keys, layer=layer)
+        else:
+            if keys_split is not None:
+                keys = [
+                    k
+                    for k in list(data.obs.keys()) + list(data.var.keys())
+                    if key in k and keys_split in k
+                ]
+                key = keys[0]
+            s_key = [s for (s, d_key) in zip(s_keys, d_keys) if key in d_key]
+            if len(s_key) == 0:
+                raise ValueError(f"'{key}' not found in any of {', '.join(s_keys)}.")
+            if len(s_key) > 1:
+                logg.warn(f"'{key}' found multiple times in {', '.join(s_key)}.")
+
+            s_key = s_key[-1]
+            df = getattr(data, s_key)[keys if len(keys) > 1 else key]
+            if key_add is not None:
+                df = df[key_add]
+            if index is None:
+                index = (
+                    data.var_names
+                    if s_key == "varm"
+                    else data.obs_names
+                    if s_key in {"obsm", "layers"}
+                    else None
+                )
+                if index is None and s_key == "uns" and hasattr(df, "shape"):
+                    key_cats = np.array(
+                        [
+                            key
+                            for key in data.obs.keys()
+                            if is_categorical_dtype(data.obs[key])
+                        ]
+                    )
+                    num_cats = [
+                        len(data.obs[key].cat.categories) == df.shape[0]
+                        for key in key_cats
+                    ]
+                    if np.sum(num_cats) == 1:
+                        index = data.obs[key_cats[num_cats][0]].cat.categories
+                        if (
+                            columns is None
+                            and len(df.shape) > 1
+                            and df.shape[0] == df.shape[1]
+                        ):
+                            columns = index
+            elif isinstance(index, str) and index in data.obs.keys():
+                index = pd.Categorical(data.obs[index]).categories
+            if columns is None and s_key == "layers":
+                columns = data.var_names
+            elif isinstance(columns, str) and columns in data.obs.keys():
+                columns = pd.Categorical(data.obs[columns]).categories
+    elif isinstance(data, pd.DataFrame):
+        if isinstance(keys, str) and "*" in keys:
+            keys, keys_split = keys.split("*")
+            keys = [k for k in data.columns if keys in k and keys_split in k]
+        df = data[keys] if keys is not None else data
+    else:
+        df = data
+
+    if issparse(df):
+        df = np.array(df.A)
+    if columns is None and hasattr(df, "names"):
+        columns = df.names
+
+    df = pd.DataFrame(df, index=index, columns=columns)
+
+    if dropna:
+        df.replace("", np.nan, inplace=True)
+        how = dropna if isinstance(dropna, str) else "any" if dropna is True else "all"
+        df.dropna(how=how, axis=0, inplace=True)
+        df.dropna(how=how, axis=1, inplace=True)
+
+    if sort_values:
+        sort_by = (
+            sort_values
+            if isinstance(sort_values, str) and sort_values in df.columns
+            else df.columns[0]
+        )
+        df = df.sort_values(by=sort_by, ascending=False)
+
+    if hasattr(data, "var_names"):
+        if df.index[0] in data.var_names:
+            df.var_names = df.index
+        elif df.columns[0] in data.var_names:
+            df.var_names = df.columns
+    if hasattr(data, "obs_names"):
+        if df.index[0] in data.obs_names:
+            df.obs_names = df.index
+        elif df.columns[0] in data.obs_names:
+            df.obs_names = df.columns
+
+    return df
 
 
 def get_initial_size(adata, layer=None, by_total_size=None):

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -423,6 +423,20 @@ def set_modality(
         return adata
 
 
+def var_df(adata, keys, layer=None):
+    lookup_keys = [k for k in keys if k in adata.obs_names]
+    if len(lookup_keys) < len(keys):
+        logg.warn(
+            f"Keys {[k for k in keys if k not in adata.obs_names]} "
+            f"were not found in `adata.obs_names`."
+        )
+
+    df = pd.DataFrame(index=adata.var_names)
+    for lookup_key in lookup_keys:
+        df[lookup_key] = adata.var_vector(lookup_key, layer=layer)
+    return df
+
+
 def verify_dtypes(adata):
     try:
         _ = adata[:, 0]

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -14,6 +14,7 @@ import scvelo.logging as logg
 from ._arithmetic import sum
 
 
+# TODO: Add type hints
 def clean_obs_names(data, base="[AGTCBDHKMNRSVWY]", ID_length=12, copy=False):
     """Clean up the obs_names.
 
@@ -91,6 +92,7 @@ def clean_obs_names(data, base="[AGTCBDHKMNRSVWY]", ID_length=12, copy=False):
     return adata if copy else None
 
 
+# TODO: Add type hints
 def cleanup(data, clean="layers", keep=None, copy=False):
     """Delete not needed attributes.
 
@@ -133,6 +135,8 @@ def cleanup(data, clean="layers", keep=None, copy=False):
     return adata if copy else None
 
 
+# TODO: Fix docstrings
+# TODO: Add type hints
 def get_df(
     data,
     keys=None,
@@ -300,6 +304,9 @@ def get_df(
     return df
 
 
+# TODO: Add docstrings
+# TODO: Add type hints
+# TODO: Generalize to arbitrary modality
 def get_initial_size(adata, layer=None, by_total_size=None):
     if by_total_size:
         sizes = [
@@ -352,6 +359,9 @@ def get_modality(adata: AnnData, modality: str) -> Union[ndarray, spmatrix]:
             return adata.obsm[modality]
 
 
+# TODO: Add docstrings
+# TODO: Add type hints
+# TODO: Generalize to arbitray modality
 def get_size(adata, layer=None):
     X = adata.X if layer is None else adata.layers[layer]
     return sum(X, axis=1)
@@ -434,6 +444,8 @@ def make_sparse(
     return adata if not inplace else None
 
 
+# TODO: Finish docstrings
+# TODO: Add type hints
 def merge(adata, ldata, copy=True):
     """Merge two annotated data matrices.
 
@@ -520,6 +532,8 @@ def merge(adata, ldata, copy=True):
     return _adata if copy else None
 
 
+# TODO: Add docstrings
+# TODO: Add type hints
 def obs_df(adata, keys, layer=None):
     lookup_keys = [k for k in keys if k in adata.var_names]
     if len(lookup_keys) < len(keys):
@@ -534,6 +548,9 @@ def obs_df(adata, keys, layer=None):
     return df
 
 
+# TODO: Add docstrings
+# TODO: Add type hints
+# TODO: Generalize to arbitrary modality
 def set_initial_size(adata, layers=None):
     if layers is None:
         layers = ["spliced", "unspliced"]
@@ -591,6 +608,8 @@ def set_modality(
         return adata
 
 
+# TODO: Finish docstrings
+# TODO: Add type hints
 def show_proportions(adata, layers=None, use_raw=True):
     """Proportions of spliced/unspliced abundances
 
@@ -626,6 +645,8 @@ def show_proportions(adata, layers=None, use_raw=True):
     print(f"Abundance of {layers_keys}: {np.round(mean_abundances, 2)}")
 
 
+# TODO: Add docstrings
+# TODO: Add type hints
 def var_df(adata, keys, layer=None):
     lookup_keys = [k for k in keys if k in adata.obs_names]
     if len(lookup_keys) < len(keys):
@@ -640,6 +661,9 @@ def var_df(adata, keys, layer=None):
     return df
 
 
+# TODO: Find better function name
+# TODO: Add docstrings
+# TODO: Add type hints
 def verify_dtypes(adata):
     try:
         _ = adata[:, 0]

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -184,3 +184,22 @@ def set_modality(
 
     if not inplace:
         return adata
+
+
+def verify_dtypes(adata):
+    try:
+        _ = adata[:, 0]
+    except Exception:
+        uns = adata.uns
+        adata.uns = {}
+        try:
+            _ = adata[:, 0]
+            logg.warn(
+                "Safely deleted unstructured annotations (adata.uns), \n"
+                "as these do not comply with permissible anndata datatypes."
+            )
+        except Exception:
+            logg.warn(
+                "The data might be corrupted. Please verify all annotation datatypes."
+            )
+            adata.uns = uns

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -352,6 +352,20 @@ def merge(adata, ldata, copy=True):
     return _adata if copy else None
 
 
+def obs_df(adata, keys, layer=None):
+    lookup_keys = [k for k in keys if k in adata.var_names]
+    if len(lookup_keys) < len(keys):
+        logg.warn(
+            f"Keys {[k for k in keys if k not in adata.var_names]} "
+            f"were not found in `adata.var_names`."
+        )
+
+    df = pd.DataFrame(index=adata.obs_names)
+    for lookup_key in lookup_keys:
+        df[lookup_key] = adata.obs_vector(lookup_key, layer=layer)
+    return df
+
+
 def set_initial_size(adata, layers=None):
     if layers is None:
         layers = ["spliced", "unspliced"]

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Union
 
+import numpy as np
 from numpy import ndarray
 from pandas import DataFrame
 from scipy.sparse import csr_matrix, issparse, spmatrix
@@ -8,6 +9,30 @@ from anndata import AnnData
 
 import scvelo.logging as logg
 from ._arithmetic import sum
+
+
+def get_initial_size(adata, layer=None, by_total_size=None):
+    if by_total_size:
+        sizes = [
+            adata.obs[f"initial_size_{layer}"]
+            for layer in {"spliced", "unspliced"}
+            if f"initial_size_{layer}" in adata.obs.keys()
+        ]
+        return np.sum(sizes, axis=0)
+    elif layer in adata.layers.keys():
+        return (
+            np.array(adata.obs[f"initial_size_{layer}"])
+            if f"initial_size_{layer}" in adata.obs.keys()
+            else get_size(adata, layer)
+        )
+    elif layer is None or layer == "X":
+        return (
+            np.array(adata.obs["initial_size"])
+            if "initial_size" in adata.obs.keys()
+            else get_size(adata)
+        )
+    else:
+        return None
 
 
 def get_modality(adata: AnnData, modality: str) -> Union[ndarray, spmatrix]:

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -145,6 +145,22 @@ def make_sparse(
     return adata if not inplace else None
 
 
+def set_initial_size(adata, layers=None):
+    if layers is None:
+        layers = ["spliced", "unspliced"]
+    verify_dtypes(adata)
+    layers = [
+        layer
+        for layer in layers
+        if layer in adata.layers.keys()
+        and f"initial_size_{layer}" not in adata.obs.keys()
+    ]
+    for layer in layers:
+        adata.obs[f"initial_size_{layer}"] = get_size(adata, layer)
+    if "initial_size" not in adata.obs.keys():
+        adata.obs["initial_size"] = get_size(adata)
+
+
 def set_modality(
     adata: AnnData,
     new_value: Union[ndarray, spmatrix, DataFrame],

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -266,6 +266,92 @@ def make_sparse(
     return adata if not inplace else None
 
 
+def merge(adata, ldata, copy=True):
+    """Merge two annotated data matrices.
+
+    Arguments
+    ---------
+    adata: :class:`~anndata.AnnData`
+        Annotated data matrix (reference data set).
+    ldata: :class:`~anndata.AnnData`
+        Annotated data matrix (to be merged into adata).
+
+    Returns
+    -------
+    Returns a :class:`~anndata.AnnData` object
+    """
+    adata.var_names_make_unique()
+    ldata.var_names_make_unique()
+
+    if (
+        "spliced" in ldata.layers.keys()
+        and "initial_size_spliced" not in ldata.obs.keys()
+    ):
+        set_initial_size(ldata)
+    elif (
+        "spliced" in adata.layers.keys()
+        and "initial_size_spliced" not in adata.obs.keys()
+    ):
+        set_initial_size(adata)
+
+    common_obs = pd.unique(adata.obs_names.intersection(ldata.obs_names))
+    common_vars = pd.unique(adata.var_names.intersection(ldata.var_names))
+
+    if len(common_obs) == 0:
+        clean_obs_names(adata)
+        clean_obs_names(ldata)
+        common_obs = adata.obs_names.intersection(ldata.obs_names)
+
+    if copy:
+        _adata = adata[common_obs].copy()
+        _ldata = ldata[common_obs].copy()
+    else:
+        adata._inplace_subset_obs(common_obs)
+        _adata, _ldata = adata, ldata[common_obs].copy()
+
+    _adata.var_names_make_unique()
+    _ldata.var_names_make_unique()
+
+    same_vars = len(_adata.var_names) == len(_ldata.var_names) and np.all(
+        _adata.var_names == _ldata.var_names
+    )
+    join_vars = len(common_vars) > 0
+
+    if join_vars and not same_vars:
+        _adata._inplace_subset_var(common_vars)
+        _ldata._inplace_subset_var(common_vars)
+
+    for attr in _ldata.obs.keys():
+        if attr not in _adata.obs.keys():
+            _adata.obs[attr] = _ldata.obs[attr]
+    for attr in _ldata.obsm.keys():
+        if attr not in _adata.obsm.keys():
+            _adata.obsm[attr] = _ldata.obsm[attr]
+    for attr in _ldata.uns.keys():
+        if attr not in _adata.uns.keys():
+            _adata.uns[attr] = _ldata.uns[attr]
+    if join_vars:
+        for attr in _ldata.layers.keys():
+            if attr not in _adata.layers.keys():
+                _adata.layers[attr] = _ldata.layers[attr]
+
+        if _adata.shape[1] == _ldata.shape[1]:
+            same_vars = len(_adata.var_names) == len(_ldata.var_names) and np.all(
+                _adata.var_names == _ldata.var_names
+            )
+            if same_vars:
+                for attr in _ldata.var.keys():
+                    if attr not in _adata.var.keys():
+                        _adata.var[attr] = _ldata.var[attr]
+                for attr in _ldata.varm.keys():
+                    if attr not in _adata.varm.keys():
+                        _adata.varm[attr] = _ldata.varm[attr]
+            else:
+                raise ValueError("Variable names are not identical.")
+
+    return _adata if copy else None
+
+
 def set_initial_size(adata, layers=None):
     if layers is None:
         layers = ["spliced", "unspliced"]

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -7,6 +7,7 @@ from scipy.sparse import csr_matrix, issparse, spmatrix
 from anndata import AnnData
 
 import scvelo.logging as logg
+from ._arithmetic import sum
 
 
 def get_modality(adata: AnnData, modality: str) -> Union[ndarray, spmatrix]:
@@ -35,6 +36,11 @@ def get_modality(adata: AnnData, modality: str) -> Union[ndarray, spmatrix]:
             return adata.obsm[modality].values
         else:
             return adata.obsm[modality]
+
+
+def get_size(adata, layer=None):
+    X = adata.X if layer is None else adata.layers[layer]
+    return sum(X, axis=1)
 
 
 def make_dense(

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -591,6 +591,41 @@ def set_modality(
         return adata
 
 
+def show_proportions(adata, layers=None, use_raw=True):
+    """Proportions of spliced/unspliced abundances
+
+    Arguments
+    ---------
+    adata: :class:`~anndata.AnnData`
+        Annotated data matrix.
+
+    Returns
+    -------
+    Prints the fractions of abundances.
+    """
+
+    if layers is None:
+        layers = ["spliced", "unspliced", "ambigious"]
+    layers_keys = [key for key in layers if key in adata.layers.keys()]
+    counts_layers = [sum(adata.layers[key], axis=1) for key in layers_keys]
+    if use_raw:
+        size_key, obs = "initial_size_", adata.obs
+        counts_layers = [
+            obs[size_key + layer] if size_key + layer in obs.keys() else c
+            for layer, c in zip(layers_keys, counts_layers)
+        ]
+
+    counts_per_cell_sum = np.sum(counts_layers, 0)
+    counts_per_cell_sum += counts_per_cell_sum == 0
+
+    mean_abundances = [
+        np.mean(counts_per_cell / counts_per_cell_sum)
+        for counts_per_cell in counts_layers
+    ]
+
+    print(f"Abundance of {layers_keys}: {np.round(mean_abundances, 2)}")
+
+
 def var_df(adata, keys, layer=None):
     lookup_keys = [k for k in keys if k in adata.obs_names]
     if len(lookup_keys) < len(keys):

--- a/scvelo/datasets.py
+++ b/scvelo/datasets.py
@@ -7,8 +7,7 @@ import pandas as pd
 from anndata import AnnData
 from scanpy import read
 
-from scvelo.core import SplicingDynamics
-from .preprocessing.utils import cleanup
+from scvelo.core import cleanup, SplicingDynamics
 from .read_load import load
 
 url_datadir = "https://github.com/theislab/scvelo_notebooks/raw/master/"

--- a/scvelo/preprocessing/neighbors.py
+++ b/scvelo/preprocessing/neighbors.py
@@ -7,9 +7,9 @@ from anndata import AnnData
 from scanpy import Neighbors
 from scanpy.preprocessing import pca
 
+from scvelo.core import get_initial_size
 from .. import logging as logg
 from .. import settings
-from .utils import get_initial_size
 
 
 def neighbors(

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -9,6 +9,7 @@ from anndata import AnnData
 
 from scvelo.core import get_initial_size as _get_initial_size
 from scvelo.core import get_size as _get_size
+from scvelo.core import set_initial_size as _set_initial_size
 from scvelo.core import sum
 from scvelo.core._anndata import verify_dtypes as _verify_dtypes
 from .. import logging as logg
@@ -140,19 +141,15 @@ def get_size(adata, layer=None):
 
 
 def set_initial_size(adata, layers=None):
-    if layers is None:
-        layers = ["spliced", "unspliced"]
-    _verify_dtypes(adata)
-    layers = [
-        layer
-        for layer in layers
-        if layer in adata.layers.keys()
-        and f"initial_size_{layer}" not in adata.obs.keys()
-    ]
-    for layer in layers:
-        adata.obs[f"initial_size_{layer}"] = _get_size(adata, layer)
-    if "initial_size" not in adata.obs.keys():
-        adata.obs["initial_size"] = _get_size(adata)
+    warnings.warn(
+        "`scvelo.preprocessing.utils.set_initial_size` is deprecated since scVelo "
+        "v0.2.4 and will be removed in a future version. Please use "
+        "`scvelo.core.set_initial_size` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return _set_initial_size(adata=adata, layers=layers)
 
 
 def get_initial_size(adata, layer=None, by_total_size=None):
@@ -249,7 +246,7 @@ def filter_genes(
     adata = data.copy() if copy else data
 
     # set initial cell sizes before filtering
-    set_initial_size(adata)
+    _set_initial_size(adata)
 
     layers = [
         layer for layer in ["spliced", "unspliced"] if layer in adata.layers.keys()
@@ -435,7 +432,7 @@ def filter_genes_dispersion(
     `copy`. It filters the `adata` and adds the annotations
     """
     adata = data.copy() if copy else data
-    set_initial_size(adata)
+    _set_initial_size(adata)
 
     mean, var = materialize_as_ndarray(get_mean_var(adata.X))
 
@@ -638,7 +635,7 @@ def normalize_per_cell(
 
     if isinstance(counts_per_cell, str):
         if counts_per_cell not in adata.obs.keys():
-            set_initial_size(adata, layers)
+            _set_initial_size(adata, layers)
         counts_per_cell = (
             adata.obs[counts_per_cell].values
             if counts_per_cell in adata.obs.keys()

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -80,8 +80,9 @@ def cleanup(data, clean="layers", keep=None, copy=False):
 
 def get_size(adata, layer=None):
     warnings.warn(
-        "`scvelo.preprocessing.get_size` is deprecated since scVelo v0.2.4 and will be "
-        "removed in a future version. Please use `scvelo.core.get_size` instead.",
+        "`scvelo.preprocessing.utils.get_size` is deprecated since scVelo v0.2.4 and "
+        "will be removed in a future version. Please use `scvelo.core.get_size` "
+        "instead.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -11,6 +11,7 @@ from scvelo.core import cleanup as _cleanup
 from scvelo.core import get_initial_size as _get_initial_size
 from scvelo.core import get_size as _get_size
 from scvelo.core import set_initial_size as _set_initial_size
+from scvelo.core import show_proportions as _show_proportions
 from scvelo.core import sum
 from scvelo.core._anndata import verify_dtypes as _verify_dtypes
 from .. import logging as logg
@@ -43,37 +44,15 @@ def sum_var(A):
 
 
 def show_proportions(adata, layers=None, use_raw=True):
-    """Proportions of spliced/unspliced abundances
+    warnings.warn(
+        "`scvelo.preprocessing.show_proportions` is deprecated since scVelo v0.2.4 "
+        "and will be removed in a future version. Please use "
+        "`scvelo.core.show_proportions` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    Arguments
-    ---------
-    adata: :class:`~anndata.AnnData`
-        Annotated data matrix.
-
-    Returns
-    -------
-    Prints the fractions of abundances.
-    """
-    if layers is None:
-        layers = ["spliced", "unspliced", "ambigious"]
-    layers_keys = [key for key in layers if key in adata.layers.keys()]
-    counts_layers = [sum(adata.layers[key], axis=1) for key in layers_keys]
-    if use_raw:
-        size_key, obs = "initial_size_", adata.obs
-        counts_layers = [
-            obs[size_key + layer] if size_key + layer in obs.keys() else c
-            for layer, c in zip(layers_keys, counts_layers)
-        ]
-
-    counts_per_cell_sum = np.sum(counts_layers, 0)
-    counts_per_cell_sum += counts_per_cell_sum == 0
-
-    mean_abundances = [
-        np.mean(counts_per_cell / counts_per_cell_sum)
-        for counts_per_cell in counts_layers
-    ]
-
-    print(f"Abundance of {layers_keys}: {np.round(mean_abundances, 2)}")
+    _show_proportions(adata=adata, layers=layers, use_raw=use_raw)
 
 
 def verify_dtypes(adata):

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -7,6 +7,7 @@ from sklearn.utils import sparsefuncs
 
 from anndata import AnnData
 
+from scvelo.core import cleanup as _cleanup
 from scvelo.core import get_initial_size as _get_initial_size
 from scvelo.core import get_size as _get_size
 from scvelo.core import set_initial_size as _set_initial_size
@@ -88,45 +89,14 @@ def verify_dtypes(adata):
 
 
 def cleanup(data, clean="layers", keep=None, copy=False):
-    """Deletes attributes not needed.
+    warnings.warn(
+        "`scvelo.preprocessing.cleanup` is deprecated since scVelo v0.2.4 and will be "
+        "removed in a future version. Please use `scvelo.core.cleanup` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    Arguments
-    ---------
-    data: :class:`~anndata.AnnData`
-        Annotated data matrix.
-    clean: `str` or list of `str` (default: `layers`)
-        Which attributes to consider for freeing memory.
-    keep: `str` or list of `str` (default: None)
-        Which attributes to keep.
-    copy: `bool` (default: `False`)
-        Return a copy instead of writing to adata.
-
-    Returns
-    -------
-    Returns or updates `adata` with selection of attributes kept.
-    """
-    adata = data.copy() if copy else data
-    _verify_dtypes(adata)
-
-    keep = list([keep] if isinstance(keep, str) else {} if keep is None else keep)
-    keep.extend(["spliced", "unspliced", "Ms", "Mu", "clusters", "neighbors"])
-
-    ann_dict = {
-        "obs": adata.obs_keys(),
-        "var": adata.var_keys(),
-        "uns": adata.uns_keys(),
-        "layers": list(adata.layers.keys()),
-    }
-
-    if "all" not in clean:
-        ann_dict = {ann: values for (ann, values) in ann_dict.items() if ann in clean}
-
-    for (ann, values) in ann_dict.items():
-        for value in values:
-            if value not in keep:
-                del getattr(adata, ann)[value]
-
-    return adata if copy else None
+    return _cleanup(data=data, clean=clean, keep=keep, copy=copy)
 
 
 def get_size(adata, layer=None):

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -7,6 +7,7 @@ from sklearn.utils import sparsefuncs
 
 from anndata import AnnData
 
+from scvelo.core import get_size as _get_size
 from scvelo.core import sum
 from .. import logging as logg
 
@@ -133,8 +134,14 @@ def cleanup(data, clean="layers", keep=None, copy=False):
 
 
 def get_size(adata, layer=None):
-    X = adata.X if layer is None else adata.layers[layer]
-    return sum(X, axis=1)
+    warnings.warn(
+        "`scvelo.preprocessing.get_size` is deprecated since scVelo v0.2.4 and will be "
+        "removed in a future version. Please use `scvelo.core.get_size` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return _get_size(adata=adata, layer=layer)
 
 
 def set_initial_size(adata, layers=None):
@@ -148,9 +155,9 @@ def set_initial_size(adata, layers=None):
         and f"initial_size_{layer}" not in adata.obs.keys()
     ]
     for layer in layers:
-        adata.obs[f"initial_size_{layer}"] = get_size(adata, layer)
+        adata.obs[f"initial_size_{layer}"] = _get_size(adata, layer)
     if "initial_size" not in adata.obs.keys():
-        adata.obs["initial_size"] = get_size(adata)
+        adata.obs["initial_size"] = _get_size(adata)
 
 
 def get_initial_size(adata, layer=None, by_total_size=None):
@@ -165,13 +172,13 @@ def get_initial_size(adata, layer=None, by_total_size=None):
         return (
             np.array(adata.obs[f"initial_size_{layer}"])
             if f"initial_size_{layer}" in adata.obs.keys()
-            else get_size(adata, layer)
+            else _get_size(adata, layer)
         )
     elif layer is None or layer == "X":
         return (
             np.array(adata.obs["initial_size"])
             if "initial_size" in adata.obs.keys()
-            else get_size(adata)
+            else _get_size(adata)
         )
     else:
         return None
@@ -665,7 +672,7 @@ def normalize_per_cell(
                 if counts_per_cell is not None
                 else get_initial_size(adata, layer)
                 if use_initial_size
-                else get_size(adata, layer)
+                else _get_size(adata, layer)
             )
             if max_proportion_per_cell is not None and (
                 0 < max_proportion_per_cell < 1
@@ -704,7 +711,7 @@ def normalize_per_cell(
                 "To enforce normalization, set `enforce=True`."
             )
 
-    adata.obs["n_counts" if key_n_counts is None else key_n_counts] = get_size(adata)
+    adata.obs["n_counts" if key_n_counts is None else key_n_counts] = _get_size(adata)
     if len(modified_layers) > 0:
         logg.info("Normalized count data:", f"{', '.join(modified_layers)}.")
 

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -7,6 +7,7 @@ from sklearn.utils import sparsefuncs
 
 from anndata import AnnData
 
+from scvelo.core import get_initial_size as _get_initial_size
 from scvelo.core import get_size as _get_size
 from scvelo.core import sum
 from .. import logging as logg
@@ -161,27 +162,15 @@ def set_initial_size(adata, layers=None):
 
 
 def get_initial_size(adata, layer=None, by_total_size=None):
-    if by_total_size:
-        sizes = [
-            adata.obs[f"initial_size_{layer}"]
-            for layer in {"spliced", "unspliced"}
-            if f"initial_size_{layer}" in adata.obs.keys()
-        ]
-        return np.sum(sizes, axis=0)
-    elif layer in adata.layers.keys():
-        return (
-            np.array(adata.obs[f"initial_size_{layer}"])
-            if f"initial_size_{layer}" in adata.obs.keys()
-            else _get_size(adata, layer)
-        )
-    elif layer is None or layer == "X":
-        return (
-            np.array(adata.obs["initial_size"])
-            if "initial_size" in adata.obs.keys()
-            else _get_size(adata)
-        )
-    else:
-        return None
+    warnings.warn(
+        "`scvelo.preprocessing.get_initial_size` is deprecated since scVelo v0.2.4 and "
+        "will be  removed in a future version. Please use "
+        "`scvelo.core.get_initial_size` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return _get_initial_size(adata=adata, layer=layer, by_total_size=by_total_size)
 
 
 def _filter(X, min_counts=None, min_cells=None, max_counts=None, max_cells=None):
@@ -670,7 +659,7 @@ def normalize_per_cell(
             counts = (
                 counts_per_cell
                 if counts_per_cell is not None
-                else get_initial_size(adata, layer)
+                else _get_initial_size(adata, layer)
                 if use_initial_size
                 else _get_size(adata, layer)
             )

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -10,6 +10,7 @@ from anndata import AnnData
 from scvelo.core import get_initial_size as _get_initial_size
 from scvelo.core import get_size as _get_size
 from scvelo.core import sum
+from scvelo.core._anndata import verify_dtypes as _verify_dtypes
 from .. import logging as logg
 
 
@@ -74,22 +75,15 @@ def show_proportions(adata, layers=None, use_raw=True):
 
 
 def verify_dtypes(adata):
-    try:
-        _ = adata[:, 0]
-    except Exception:
-        uns = adata.uns
-        adata.uns = {}
-        try:
-            _ = adata[:, 0]
-            logg.warn(
-                "Safely deleted unstructured annotations (adata.uns), \n"
-                "as these do not comply with permissible anndata datatypes."
-            )
-        except Exception:
-            logg.warn(
-                "The data might be corrupted. Please verify all annotation datatypes."
-            )
-            adata.uns = uns
+    warnings.warn(
+        "`scvelo.preprocessing.utils.verify_dtypes` is deprecated since scVelo v0.2.4 "
+        "and will be removed in a future version. Please use "
+        "`scvelo.core._anndata.verify_dtypes` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return _verify_dtypes(adata=adata)
 
 
 def cleanup(data, clean="layers", keep=None, copy=False):
@@ -111,7 +105,7 @@ def cleanup(data, clean="layers", keep=None, copy=False):
     Returns or updates `adata` with selection of attributes kept.
     """
     adata = data.copy() if copy else data
-    verify_dtypes(adata)
+    _verify_dtypes(adata)
 
     keep = list([keep] if isinstance(keep, str) else {} if keep is None else keep)
     keep.extend(["spliced", "unspliced", "Ms", "Mu", "clusters", "neighbors"])
@@ -148,7 +142,7 @@ def get_size(adata, layer=None):
 def set_initial_size(adata, layers=None):
     if layers is None:
         layers = ["spliced", "unspliced"]
-    verify_dtypes(adata)
+    _verify_dtypes(adata)
     layers = [
         layer
         for layer in layers

--- a/scvelo/read_load.py
+++ b/scvelo/read_load.py
@@ -13,6 +13,7 @@ from anndata import AnnData
 from scvelo.core import clean_obs_names as _clean_obs_names
 from scvelo.core import merge as _merge
 from scvelo.core._anndata import obs_df as _obs_df
+from scvelo.core._anndata import var_df as _var_df
 from . import logging as logg
 
 
@@ -98,17 +99,15 @@ def obs_df(adata, keys, layer=None):
 
 
 def var_df(adata, keys, layer=None):
-    lookup_keys = [k for k in keys if k in adata.obs_names]
-    if len(lookup_keys) < len(keys):
-        logg.warn(
-            f"Keys {[k for k in keys if k not in adata.obs_names]} "
-            f"were not found in `adata.obs_names`."
-        )
+    warnings.warn(
+        "`scvelo.read_load.var_df` is deprecated since scVelo v0.2.4 and will be "
+        "removed in a future version. Please use `scvelo.core._anndata.var_df` "
+        "instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    df = pd.DataFrame(index=adata.var_names)
-    for lookup_key in lookup_keys:
-        df[lookup_key] = adata.var_vector(lookup_key, layer=layer)
-    return df
+    return _var_df(adata=adata, keys=keys, layer=layer)
 
 
 def get_df(
@@ -182,7 +181,7 @@ def get_df(
         elif key in data.var_names:
             df = _obs_df(data, keys, layer=layer)
         elif key in data.obs_names:
-            df = var_df(data, keys, layer=layer)
+            df = _var_df(data, keys, layer=layer)
         else:
             if keys_split is not None:
                 keys = [

--- a/scvelo/read_load.py
+++ b/scvelo/read_load.py
@@ -10,8 +10,8 @@ from scipy.sparse import issparse
 
 from anndata import AnnData
 
+from scvelo.core import set_initial_size
 from . import logging as logg
-from .preprocessing.utils import set_initial_size
 
 
 def load(filename, backup_url=None, header="infer", index_col="infer", **kwargs):

--- a/scvelo/read_load.py
+++ b/scvelo/read_load.py
@@ -5,16 +5,12 @@ from urllib.request import urlretrieve
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_categorical_dtype
-from scipy.sparse import issparse
-
-from anndata import AnnData
 
 from scvelo.core import clean_obs_names as _clean_obs_names
+from scvelo.core import get_df as _get_df
 from scvelo.core import merge as _merge
 from scvelo.core._anndata import obs_df as _obs_df
 from scvelo.core._anndata import var_df as _var_df
-from . import logging as logg
 
 
 def load(filename, backup_url=None, header="infer", index_col="infer", **kwargs):
@@ -120,161 +116,23 @@ def get_df(
     dropna="all",
     precision=None,
 ):
-    """Get dataframe for a specified adata key.
+    warnings.warn(
+        "`scvelo.read_load.get_df` is deprecated since scVelo v0.2.4 and will be "
+        "removed in a future version. Please use `scvelo.core.get_df` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    Return values for specified key
-    (in obs, var, obsm, varm, obsp, varp, uns, or layers) as a dataframe.
-
-    Arguments
-    ------
-    adata
-        AnnData object or a numpy array to get values from.
-    keys
-        Keys from `.var_names`, `.obs_names`, `.var`, `.obs`,
-        `.obsm`, `.varm`, `.obsp`, `.varp`, `.uns`, or `.layers`.
-    layer
-        Layer of `adata` to use as expression values.
-    index
-        List to set as index.
-    columns
-        List to set as columns names.
-    sort_values
-        Wether to sort values by first column (sort_values=True) or a specified column.
-    dropna
-        Drop columns/rows that contain NaNs in all ('all') or in any entry ('any').
-    precision
-        Set precision for pandas dataframe.
-
-    Returns
-    -------
-    A dataframe.
-    """
-    if precision is not None:
-        pd.set_option("precision", precision)
-
-    if isinstance(data, AnnData):
-        keys, keys_split = (
-            keys.split("*") if isinstance(keys, str) and "*" in keys else (keys, None)
-        )
-        keys, key_add = (
-            keys.split("/") if isinstance(keys, str) and "/" in keys else (keys, None)
-        )
-        keys = [keys] if isinstance(keys, str) else keys
-        key = keys[0]
-
-        s_keys = ["obs", "var", "obsm", "varm", "uns", "layers"]
-        d_keys = [
-            data.obs.keys(),
-            data.var.keys(),
-            data.obsm.keys(),
-            data.varm.keys(),
-            data.uns.keys(),
-            data.layers.keys(),
-        ]
-
-        if hasattr(data, "obsp") and hasattr(data, "varp"):
-            s_keys.extend(["obsp", "varp"])
-            d_keys.extend([data.obsp.keys(), data.varp.keys()])
-
-        if keys is None:
-            df = data.to_df()
-        elif key in data.var_names:
-            df = _obs_df(data, keys, layer=layer)
-        elif key in data.obs_names:
-            df = _var_df(data, keys, layer=layer)
-        else:
-            if keys_split is not None:
-                keys = [
-                    k
-                    for k in list(data.obs.keys()) + list(data.var.keys())
-                    if key in k and keys_split in k
-                ]
-                key = keys[0]
-            s_key = [s for (s, d_key) in zip(s_keys, d_keys) if key in d_key]
-            if len(s_key) == 0:
-                raise ValueError(f"'{key}' not found in any of {', '.join(s_keys)}.")
-            if len(s_key) > 1:
-                logg.warn(f"'{key}' found multiple times in {', '.join(s_key)}.")
-
-            s_key = s_key[-1]
-            df = getattr(data, s_key)[keys if len(keys) > 1 else key]
-            if key_add is not None:
-                df = df[key_add]
-            if index is None:
-                index = (
-                    data.var_names
-                    if s_key == "varm"
-                    else data.obs_names
-                    if s_key in {"obsm", "layers"}
-                    else None
-                )
-                if index is None and s_key == "uns" and hasattr(df, "shape"):
-                    key_cats = np.array(
-                        [
-                            key
-                            for key in data.obs.keys()
-                            if is_categorical_dtype(data.obs[key])
-                        ]
-                    )
-                    num_cats = [
-                        len(data.obs[key].cat.categories) == df.shape[0]
-                        for key in key_cats
-                    ]
-                    if np.sum(num_cats) == 1:
-                        index = data.obs[key_cats[num_cats][0]].cat.categories
-                        if (
-                            columns is None
-                            and len(df.shape) > 1
-                            and df.shape[0] == df.shape[1]
-                        ):
-                            columns = index
-            elif isinstance(index, str) and index in data.obs.keys():
-                index = pd.Categorical(data.obs[index]).categories
-            if columns is None and s_key == "layers":
-                columns = data.var_names
-            elif isinstance(columns, str) and columns in data.obs.keys():
-                columns = pd.Categorical(data.obs[columns]).categories
-    elif isinstance(data, pd.DataFrame):
-        if isinstance(keys, str) and "*" in keys:
-            keys, keys_split = keys.split("*")
-            keys = [k for k in data.columns if keys in k and keys_split in k]
-        df = data[keys] if keys is not None else data
-    else:
-        df = data
-
-    if issparse(df):
-        df = np.array(df.A)
-    if columns is None and hasattr(df, "names"):
-        columns = df.names
-
-    df = pd.DataFrame(df, index=index, columns=columns)
-
-    if dropna:
-        df.replace("", np.nan, inplace=True)
-        how = dropna if isinstance(dropna, str) else "any" if dropna is True else "all"
-        df.dropna(how=how, axis=0, inplace=True)
-        df.dropna(how=how, axis=1, inplace=True)
-
-    if sort_values:
-        sort_by = (
-            sort_values
-            if isinstance(sort_values, str) and sort_values in df.columns
-            else df.columns[0]
-        )
-        df = df.sort_values(by=sort_by, ascending=False)
-
-    if hasattr(data, "var_names"):
-        if df.index[0] in data.var_names:
-            df.var_names = df.index
-        elif df.columns[0] in data.var_names:
-            df.var_names = df.columns
-    if hasattr(data, "obs_names"):
-        if df.index[0] in data.obs_names:
-            df.obs_names = df.index
-        elif df.columns[0] in data.obs_names:
-            df.obs_names = df.columns
-
-    return df
+    return _get_df(
+        data=data,
+        keys=keys,
+        layer=layer,
+        index=index,
+        columns=columns,
+        sort_values=sort_values,
+        dropna=dropna,
+        precision=precision,
+    )
 
 
 DataFrame = get_df

--- a/scvelo/read_load.py
+++ b/scvelo/read_load.py
@@ -12,6 +12,7 @@ from anndata import AnnData
 
 from scvelo.core import clean_obs_names as _clean_obs_names
 from scvelo.core import merge as _merge
+from scvelo.core._anndata import obs_df as _obs_df
 from . import logging as logg
 
 
@@ -85,17 +86,15 @@ def merge(adata, ldata, copy=True):
 
 
 def obs_df(adata, keys, layer=None):
-    lookup_keys = [k for k in keys if k in adata.var_names]
-    if len(lookup_keys) < len(keys):
-        logg.warn(
-            f"Keys {[k for k in keys if k not in adata.var_names]} "
-            f"were not found in `adata.var_names`."
-        )
+    warnings.warn(
+        "`scvelo.read_load.obs_df` is deprecated since scVelo v0.2.4 and will be "
+        "removed in a future version. Please use `scvelo.core._anndata.obs_df` "
+        "instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    df = pd.DataFrame(index=adata.obs_names)
-    for lookup_key in lookup_keys:
-        df[lookup_key] = adata.obs_vector(lookup_key, layer=layer)
-    return df
+    return _obs_df(adata=adata, keys=keys, layer=layer)
 
 
 def var_df(adata, keys, layer=None):
@@ -181,7 +180,7 @@ def get_df(
         if keys is None:
             df = data.to_df()
         elif key in data.var_names:
-            df = obs_df(data, keys, layer=layer)
+            df = _obs_df(data, keys, layer=layer)
         elif key in data.obs_names:
             df = var_df(data, keys, layer=layer)
         else:

--- a/scvelo/utils.py
+++ b/scvelo/utils.py
@@ -4,6 +4,7 @@ from scvelo.core import (
     get_initial_size,
     merge,
     set_initial_size,
+    show_proportions,
 )
 from .plotting.simulation import compute_dynamics
 from .plotting.utils import (
@@ -15,7 +16,6 @@ from .plotting.utils import (
 from .plotting.velocity_embedding_grid import compute_velocity_on_grid
 from .preprocessing.moments import get_moments
 from .preprocessing.neighbors import get_connectivities
-from .preprocessing.utils import show_proportions
 from .read_load import (
     convert_to_ensembl,
     convert_to_gene_names,

--- a/scvelo/utils.py
+++ b/scvelo/utils.py
@@ -1,4 +1,10 @@
-from scvelo.core import clean_obs_names, cleanup, get_initial_size, set_initial_size
+from scvelo.core import (
+    clean_obs_names,
+    cleanup,
+    get_initial_size,
+    merge,
+    set_initial_size,
+)
 from .plotting.simulation import compute_dynamics
 from .plotting.utils import (
     clip,
@@ -15,7 +21,6 @@ from .read_load import (
     convert_to_gene_names,
     gene_info,
     load_biomart,
-    merge,
 )
 from .tools.optimization import get_weight, leastsq
 from .tools.rank_velocity_genes import get_mean_var

--- a/scvelo/utils.py
+++ b/scvelo/utils.py
@@ -1,4 +1,4 @@
-from scvelo.core import get_initial_size, set_initial_size
+from scvelo.core import clean_obs_names, get_initial_size, set_initial_size
 from .plotting.simulation import compute_dynamics
 from .plotting.utils import (
     clip,
@@ -11,7 +11,6 @@ from .preprocessing.moments import get_moments
 from .preprocessing.neighbors import get_connectivities
 from .preprocessing.utils import cleanup, show_proportions
 from .read_load import (
-    clean_obs_names,
     convert_to_ensembl,
     convert_to_gene_names,
     gene_info,

--- a/scvelo/utils.py
+++ b/scvelo/utils.py
@@ -1,3 +1,4 @@
+from scvelo.core import get_initial_size
 from .plotting.simulation import compute_dynamics
 from .plotting.utils import (
     clip,
@@ -8,12 +9,7 @@ from .plotting.utils import (
 from .plotting.velocity_embedding_grid import compute_velocity_on_grid
 from .preprocessing.moments import get_moments
 from .preprocessing.neighbors import get_connectivities
-from .preprocessing.utils import (
-    cleanup,
-    get_initial_size,
-    set_initial_size,
-    show_proportions,
-)
+from .preprocessing.utils import cleanup, set_initial_size, show_proportions
 from .read_load import (
     clean_obs_names,
     convert_to_ensembl,

--- a/scvelo/utils.py
+++ b/scvelo/utils.py
@@ -1,4 +1,4 @@
-from scvelo.core import clean_obs_names, get_initial_size, set_initial_size
+from scvelo.core import clean_obs_names, cleanup, get_initial_size, set_initial_size
 from .plotting.simulation import compute_dynamics
 from .plotting.utils import (
     clip,
@@ -9,7 +9,7 @@ from .plotting.utils import (
 from .plotting.velocity_embedding_grid import compute_velocity_on_grid
 from .preprocessing.moments import get_moments
 from .preprocessing.neighbors import get_connectivities
-from .preprocessing.utils import cleanup, show_proportions
+from .preprocessing.utils import show_proportions
 from .read_load import (
     convert_to_ensembl,
     convert_to_gene_names,

--- a/scvelo/utils.py
+++ b/scvelo/utils.py
@@ -1,4 +1,4 @@
-from scvelo.core import get_initial_size
+from scvelo.core import get_initial_size, set_initial_size
 from .plotting.simulation import compute_dynamics
 from .plotting.utils import (
     clip,
@@ -9,7 +9,7 @@ from .plotting.utils import (
 from .plotting.velocity_embedding_grid import compute_velocity_on_grid
 from .preprocessing.moments import get_moments
 from .preprocessing.neighbors import get_connectivities
-from .preprocessing.utils import cleanup, set_initial_size, show_proportions
+from .preprocessing.utils import cleanup, show_proportions
 from .read_load import (
     clean_obs_names,
     convert_to_ensembl,


### PR DESCRIPTION
## Changes

Functions related to or performing operations on AnnData, are moved to `core/_anndata.py`.
* Functions moved from `preprocessing/utils.py`: `cleanup`, `get_initial_size`, `get_size`, `set_initial_size`, `show_proportions`, `verify_dtypes`. 
* Functions moved `read_load.py`: `clean_obs_names`, `get_df`, `merge`, `obs_df`, `var_df`.

## Related issues

Related to #389.