### PR TITLE
Generalize filtering based on counts

### DIFF
--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -13,6 +13,7 @@ from ._anndata import (
     show_proportions,
 )
 from ._arithmetic import clipped_log, invert, prod_sum, sum
+from ._base import ScveloBase
 from ._linear_models import LinearRegression
 from ._metrics import l2_norm
 from ._models import SplicingDynamics
@@ -35,6 +36,7 @@ __all__ = [
     "merge",
     "parallelize",
     "prod_sum",
+    "ScveloBase",
     "set_initial_size",
     "set_modality",
     "show_proportions",

--- a/scvelo/core/_base.py
+++ b/scvelo/core/_base.py
@@ -55,3 +55,17 @@ class DynamicsBase(ABC):
         """
 
         return
+
+
+class ScveloBase(ABC):
+    def __init__(self, inplace: bool = True):
+        """Abstract base class for protein velocity.
+
+        Arguments
+        ---------
+        inplace
+            Boolean flag to indicate whether operations on annotaded data should be
+            performed inplace or not. Otherwise, it is ignored.
+        """
+
+        self.inplace = inplace

--- a/scvelo/preprocessing/_filter.py
+++ b/scvelo/preprocessing/_filter.py
@@ -73,8 +73,8 @@ class CellCountFilter(CountFilterBase):
         self,
         inplace: bool = True,
         enforce: bool = False,
-        min_n_obs: Optional[int] = None,
-        max_n_obs: Optional[int] = None,
+        min_cells: Optional[int] = None,
+        max_cells: Optional[int] = None,
         shared_counts: bool = False,
     ):
         """Class to filter variables based on number of observations expressing them.
@@ -86,10 +86,10 @@ class CellCountFilter(CountFilterBase):
             performed inplace or not. Otherwise, it is ignored.
         enforce
             Boolean flag to enforce filtering modalities.
-        min_n_obs
+        min_cells
             Minimum number of observations in which a variable is expressed to not be
             filtered out.
-        max_n_obs
+        max_cells
             Maximum number of observations in which a variable is expressed to not be
             filtered out.
         shared_counts
@@ -99,8 +99,8 @@ class CellCountFilter(CountFilterBase):
         super().__init__(
             inplace=inplace,
             enforce=enforce,
-            lower_bound=min_n_obs,
-            upper_bound=max_n_obs,
+            lower_bound=min_cells,
+            upper_bound=max_cells,
             shared_counts=shared_counts,
         )
 

--- a/scvelo/preprocessing/_filter.py
+++ b/scvelo/preprocessing/_filter.py
@@ -68,6 +68,7 @@ def _log_progress(
             )
 
 
+# TODO: Find better name
 class CellCountFilter(CountFilterBase):
     def __init__(
         self,
@@ -179,6 +180,7 @@ class CellCountFilter(CountFilterBase):
         return adata if not self.inplace else None
 
 
+# TODO: Find better name
 class GeneCountFilter(CountFilterBase):
     def __init__(
         self,

--- a/scvelo/preprocessing/_filter.py
+++ b/scvelo/preprocessing/_filter.py
@@ -1,0 +1,176 @@
+from typing import Dict, List, Optional, Set
+
+from typing_extensions import Literal
+
+import numpy as np
+from numpy import ndarray
+
+from anndata import AnnData
+
+import scvelo.logging as logg
+from scvelo.core import get_modality
+from ._preprocessing_base import CountFilterBase
+
+
+def _log_progress(
+    kind: Literal["cell_count"],
+    filter_mask: ndarray,
+    modality: str,
+    lower_bound: float,
+    upper_bound: float,
+) -> None:
+    """Log filter progress.
+
+    Arguments
+    ---------
+    kind
+        Kind of filter applied.
+    filter_mask
+        Filter mask applied.
+    modality
+        Modality being filtered.
+    lower_bound
+        Lower bound for variable to be filtered.
+    upper_bound
+        Upper bound for variable to be filtered.
+    """
+
+    n_filtered_genes = np.invert(filter_mask).sum()
+
+    # Final log: Filtered out X genes CONNECTING_PHRASE less / more than Y FILTER_BASE
+    if kind == "cell_count":
+        connecting_phrase = "detected in"
+        filter_base = "cells"
+
+    if n_filtered_genes > 0:
+        logg.info(f"Filtered out {n_filtered_genes} genes ", end=" ")
+
+        if not np.isinf(lower_bound) and not np.isinf(upper_bound):
+            logg.info(
+                f"{connecting_phrase} less than {lower_bound} and more than "
+                f"{upper_bound} {filter_base} ({modality}).",
+                no_indent=True,
+            )
+        elif np.isinf(upper_bound):
+            logg.info(
+                f"{connecting_phrase} less than {lower_bound} {filter_base} "
+                "({modality}).",
+                no_indent=True,
+            )
+        elif np.isinf(lower_bound):
+            logg.info(
+                f"{connecting_phrase} more than {lower_bound} {filter_base} "
+                "({modality}).",
+                no_indent=True,
+            )
+
+
+class CellCountFilter(CountFilterBase):
+    def __init__(
+        self,
+        inplace: bool = True,
+        enforce: bool = False,
+        min_n_obs: Optional[int] = None,
+        max_n_obs: Optional[int] = None,
+        shared_counts: bool = False,
+    ):
+        """Class to filter variables based on number of observations expressing them.
+
+        Arguments
+        ---------
+        inplace
+            Boolean flag to indicate whether operations on annotaded data should be
+            performed inplace or not. Otherwise, it is ignored.
+        enforce
+            Boolean flag to enforce filtering modalities.
+        min_n_obs
+            Minimum number of observations in which a variable is expressed to not be
+            filtered out.
+        max_n_obs
+            Maximum number of observations in which a variable is expressed to not be
+            filtered out.
+        shared_counts
+            Boolearn flag to filter by shared counts
+        """
+
+        super().__init__(
+            inplace=inplace,
+            enforce=enforce,
+            lower_bound=min_n_obs,
+            upper_bound=max_n_obs,
+            shared_counts=shared_counts,
+        )
+
+    def _transform(
+        self,
+        adata: AnnData,
+        modalities: Set,
+        vars_to_keep: Optional[Dict[str, List[int]]] = None,
+    ) -> Optional[AnnData]:
+        """Filter out genes in modalities.
+
+        Arguments
+        ---------
+        adata
+            Annotated data matrix of shape `n_obs` × `n_vars`. Rows correspond to cells,
+            columns to genes.
+        modalities
+            Set of modalities to filter.
+        vars_to_keep
+            Dictionary of variables to keep for a modality. If `None`, no variables are
+            excluded from filtering.
+
+        Returns
+        -------
+        Optional[AnnData]
+            Returns annotated data if `self.inplace` is set to `False`, `None`
+            otherwise.
+        """
+
+        if vars_to_keep is None:
+            vars_to_keep = {}
+
+        if self.shared_counts:
+            shared_counts = self._sum_shared_counts(adata=adata, modalities=modalities)
+
+            filter_mask = self.get_filter_mask(
+                adata=adata,
+                modality=shared_counts > 0,
+                vars_to_keep=list(set().union(*vars_to_keep.values())),
+            )
+
+            # Filtering by shared counts requires the count matrices of the modalities
+            # to be of the same size. As the filter mask is the same across all
+            # modalities, it suffices to filter one modality, which automatically
+            # filters all.
+            self._subset_var(
+                adata=adata, modality=modalities.pop(), filter_mask=filter_mask
+            )
+
+            _log_progress(
+                kind="cell_count",
+                filter_mask=filter_mask,
+                modality="shared",
+                lower_bound=self.lower_bound,
+                upper_bound=self.upper_bound,
+            )
+        else:
+            for modality in modalities:
+                filter_mask = self.get_filter_mask(
+                    adata=adata,
+                    modality=get_modality(adata=adata, modality=modality) > 0,
+                    vars_to_keep=vars_to_keep.get(modality, []),
+                )
+                self._subset_var(
+                    adata=adata, modality=modality, filter_mask=filter_mask
+                )
+
+                _log_progress(
+                    kind="cell_count",
+                    filter_mask=filter_mask,
+                    modality=modality,
+                    lower_bound=self.lower_bound,
+                    upper_bound=self.upper_bound,
+                )
+
+        return adata if not self.inplace else None

--- a/scvelo/preprocessing/_filter.py
+++ b/scvelo/preprocessing/_filter.py
@@ -13,7 +13,7 @@ from ._preprocessing_base import CountFilterBase
 
 
 def _log_progress(
-    kind: Literal["cell_count"],
+    kind: Literal["cell_count", "gene_count"],
     filter_mask: ndarray,
     modality: str,
     lower_bound: float,
@@ -41,6 +41,9 @@ def _log_progress(
     if kind == "cell_count":
         connecting_phrase = "detected in"
         filter_base = "cells"
+    elif kind == "gene_count":
+        connecting_phrase = "with"
+        filter_base = "counts"
 
     if n_filtered_genes > 0:
         logg.info(f"Filtered out {n_filtered_genes} genes ", end=" ")
@@ -167,6 +170,114 @@ class CellCountFilter(CountFilterBase):
 
                 _log_progress(
                     kind="cell_count",
+                    filter_mask=filter_mask,
+                    modality=modality,
+                    lower_bound=self.lower_bound,
+                    upper_bound=self.upper_bound,
+                )
+
+        return adata if not self.inplace else None
+
+
+class GeneCountFilter(CountFilterBase):
+    def __init__(
+        self,
+        inplace: bool = True,
+        enforce: bool = False,
+        min_counts: Optional[int] = None,
+        max_counts: Optional[int] = None,
+        shared_counts: bool = False,
+    ):
+        """Class for filtering variables based on counts across all observations.
+
+        Arguments
+        ---------
+        inplace
+            Boolean flag to indicate whether operations on annotaded data should be
+            performed inplace or not. Otherwise, it is ignored.
+        enforce
+            Boolean flag to enforce filtering modalities.
+        min_counts
+            Minimum number of counts of a variable to not be filtered out.
+        max_counts
+            Maximum number of counts of a variable to not be filtered out.
+        shared_counts
+            Boolearn flag to filter by shared counts.
+        """
+
+        super().__init__(
+            inplace=inplace,
+            enforce=enforce,
+            lower_bound=min_counts,
+            upper_bound=max_counts,
+            shared_counts=shared_counts,
+        )
+
+    def _transform(
+        self,
+        adata: AnnData,
+        modalities: Set,
+        vars_to_keep: Optional[Dict[str, List[int]]] = None,
+    ) -> Optional[AnnData]:
+        """Filter out genes in modalities.
+
+        Arguments
+        ---------
+        adata
+            Annotated data matrix of shape `n_obs` × `n_vars`.
+        modalities
+            Set of modalities to filter.
+        vars_to_keep
+            Dictionary of variables to keep for a modality. If `None`, no variables are
+            excluded from filtering.
+
+        Returns
+        -------
+        Optional[AnnData]
+            Returns annotated data if `self.inplace` is set to `False`, `None`
+            otherwise.
+        """
+
+        if vars_to_keep is None:
+            vars_to_keep = {}
+
+        if self.shared_counts:
+            shared_counts = self._sum_shared_counts(adata=adata, modalities=modalities)
+
+            filter_mask = self.get_filter_mask(
+                adata=adata,
+                modality=shared_counts,
+                vars_to_keep=list(set().union(*vars_to_keep.values())),
+            )
+
+            # Filtering by shared counts requires the count matrices of the modalities
+            # to be of the same size. As the filter mask is the same across all
+            # modalities, it suffices to filter one modality, which automatically
+            # filters all.
+            self._subset_var(
+                adata=adata, modality=modalities.pop(), filter_mask=filter_mask
+            )
+
+            _log_progress(
+                kind="gene_count",
+                filter_mask=filter_mask,
+                modality="shared",
+                lower_bound=self.lower_bound,
+                upper_bound=self.upper_bound,
+            )
+        else:
+            for modality in modalities:
+                filter_mask = self.get_filter_mask(
+                    adata=adata,
+                    modality=get_modality(adata=adata, modality=modality),
+                    vars_to_keep=vars_to_keep.get(modality, []),
+                )
+                self._subset_var(
+                    adata=adata, modality=modality, filter_mask=filter_mask
+                )
+
+                _log_progress(
+                    kind="gene_count",
                     filter_mask=filter_mask,
                     modality=modality,
                     lower_bound=self.lower_bound,

--- a/scvelo/preprocessing/_preprocessing_base.py
+++ b/scvelo/preprocessing/_preprocessing_base.py
@@ -1,0 +1,226 @@
+from abc import abstractmethod
+from typing import List, Optional, Set, Union
+
+import numpy as np
+from numpy import ndarray
+from scipy.sparse import issparse
+
+from anndata import AnnData
+
+import scvelo.logging as logg
+from scvelo.core import get_modality, ScveloBase, sum
+
+
+# TODO: Add `fit` and `fit_transform`
+class PreprocessingBase(ScveloBase):
+    def __init__(self, inplace: bool = True, enforce: bool = False):
+        """Base class for preprocessing of data to find protein velocity.
+
+        Arguments
+        ---------
+        inplace
+            Boolean flag to indicate whether operations on annotaded data should be
+            performed inplace or not. Otherwise, it is ignored.
+        enforce
+            Boolean flag to enforce preprocessing step.
+        """
+
+        super().__init__(inplace=inplace)
+        self.enforce = enforce
+
+    def __call__(self, data, modalities, **kwargs):
+        return self.transform(data, modalities, **kwargs)
+
+    def _is_normalized(
+        self,
+        adata: AnnData,
+        modality: str,
+        n_cells: Optional[int] = 5,
+        atol: float = 1e-3,
+    ) -> Optional[bool]:
+        """Check if a modality is not normalized.
+
+        Arguments
+        ---------
+        adata
+            Annotated data to check for normalization.
+        modality
+            Name of modality to check.
+        n_cells
+            Number of cells to check normalization on.
+        atol
+            Absolute tolerance for deciding whether modality is normalized or not.
+
+        Returns
+        -------
+        Optional[bool]
+            `True` if modality looks normalized, `False` otherwise.
+        """
+
+        data_matrix = get_modality(adata=adata, modality=modality)
+        if issparse(data_matrix):
+            data_matrix = data_matrix[:n_cells].data
+        else:
+            data_matrix = data_matrix[:n_cells]
+
+        if np.allclose(data_matrix % 1, 0, atol=atol):
+            return False
+        else:
+            return True
+
+    def _remove_normalized_modalities(
+        self, adata: AnnData, modalities: Set, task: str = None
+    ):
+        """Remove normalized modalities.
+
+        Arguments
+        ---------
+        adata
+            Annotated data object.
+        modalities
+            Set of modalities.
+        task
+            Preprocessing task.
+        """
+
+        normalized_modalities = set()
+
+        for modality in modalities:
+            if self._is_normalized(adata, modality):
+                if task is None:
+                    logg.warn(
+                        f"Modality `{modality}` is excluded as it looks already "
+                        "normalized."
+                    )
+                else:
+                    logg.warn(
+                        f"Modality `{modality}` is excluded from {task} as it looks "
+                        "already normalized."
+                    )
+                normalized_modalities.add(modality)
+
+        modalities -= normalized_modalities
+
+    def _remove_not_normalized_modalities(
+        self, adata: AnnData, modalities: Set, task: str = None
+    ):
+        """Remove not normalized modalities.
+
+        Arguments
+        ---------
+        adata
+            Annotated data object.
+        modalities
+            Set of modalities.
+        task
+            Preprocessing task.
+        """
+
+        not_normalized_modalities = set()
+        for modality in modalities:
+            if not self._is_normalized(adata, modality):
+                if task is None:
+                    logg.warn(
+                        f"Modality `{modality}` is excluded as it seems not yet "
+                        "normalized."
+                    )
+                else:
+                    logg.warn(
+                        f"Modality `{modality}` is excluded from {task} as it seems "
+                        "not yet normalized."
+                    )
+                not_normalized_modalities.add(modality)
+
+        modalities -= not_normalized_modalities
+
+    def _set_initial_counts(self, adata: AnnData):
+        """Set initial counts of modalities.
+
+        Arguments
+        ---------
+        adata
+            Annotated data object.
+        modalities
+            Set of modalities.
+        """
+
+        for modality in {"X"} | {*adata.layers} | {*adata.obsm}:
+            if modality == "X":
+                if "initial_size" not in adata.obs.columns:
+                    adata.obs["initial_size"] = sum(
+                        get_modality(adata=adata, modality=modality), axis=1
+                    )
+            elif f"initial_size_{modality}" not in adata.obs.columns:
+                adata.obs[f"initial_size_{modality}"] = sum(
+                    get_modality(adata=adata, modality=modality), axis=1
+                )
+
+    # TODO: Handle case where initial counts have not been set
+    def _get_initial_counts(self, adata: AnnData, modality: str) -> ndarray:
+        """Retrieve initial counts per observation.
+
+        Arguments
+        ---------
+        adata
+            Annotated data object.
+        modality
+            Name of modality for which to retrieve initial counts.
+
+        Returns
+        -------
+        ndarray
+            Initial counts of specified modality.
+        """
+
+        if modality == "X":
+            return adata.obs["initial_size"].values
+        else:
+            return adata.obs[f"initial_size_{modality}"].values
+
+    @abstractmethod
+    def _transform(
+        self, adata: AnnData, modalities: Set, **kwargs
+    ) -> Optional[AnnData]:
+        pass
+
+    def _update_modalities(self, adata: AnnData, modalities: Set):
+        pass
+
+    # TODO: Allow more general input type for `data`
+    def transform(
+        self, data: AnnData, modalities: Optional[Union[List, str]] = None, **kwargs
+    ) -> Optional[AnnData]:
+        """Transform data
+
+        Arguments
+        ---------
+        adata
+            Annotated data object.
+        modality
+            Name of modality for which to retrieve initial counts.
+
+        Returns
+        -------
+        Optional[AnnData]
+            Transformed annotated data is `inplace` was set to `False`, `None`
+            otherwise.
+        """
+
+        adata = data.copy() if not self.inplace else data
+        if isinstance(modalities, str):
+            modalities = [modalities]
+
+        if modalities is None:
+            modalities = {"X"}
+        else:
+            # TODO: Add warning if provided modalities do not exist
+            modalities = set(modalities) & ({"X"} | {*adata.layers} | {*adata.obsm})
+
+        if not self.enforce:
+            self._update_modalities(adata=adata, modalities=modalities)
+
+        self._set_initial_counts(adata=adata)
+
+        adata = self._transform(adata=adata, modalities=modalities, **kwargs)
+
+        return adata if not self.inplace else None

--- a/scvelo/preprocessing/tests/test_filter.py
+++ b/scvelo/preprocessing/tests/test_filter.py
@@ -14,9 +14,9 @@ from scvelo.preprocessing._filter import CellCountFilter, GeneCountFilter
 # TODO: Decouple function `_get_n_vars_final` as it is the same for
 # `TestGeneCountFilter`
 class TestCellCountFilter(TestBase):
-    def _get_n_vars_final(self, adata, modalities_to_filter, min_n_obs, max_n_obs):
+    def _get_n_vars_final(self, adata, modalities_to_filter, min_cells, max_cells):
         n_vars_final = {
-            key: ((val.sum(axis=0) >= min_n_obs) & (val.sum(axis=0) <= max_n_obs)).sum()
+            key: ((val.sum(axis=0) >= min_cells) & (val.sum(axis=0) <= max_cells)).sum()
             for key, val in modalities_to_filter.items()
             if key in adata.obsm
         }
@@ -32,8 +32,8 @@ class TestCellCountFilter(TestBase):
                     np.all,
                     zip(
                         *[
-                            (val.sum(axis=0) >= min_n_obs)
-                            & (val.sum(axis=0) <= max_n_obs)
+                            (val.sum(axis=0) >= min_cells)
+                            & (val.sum(axis=0) <= max_cells)
                             for key, val in x_or_layers.items()
                         ]
                     ),
@@ -48,8 +48,8 @@ class TestCellCountFilter(TestBase):
         adata=get_adata(),
         inplace=st.booleans(),
         enforce=st.booleans(),
-        min_n_obs=st.integers(min_value=-1000, max_value=1000),
-        max_n_obs=st.integers(min_value=-1000, max_value=1000),
+        min_cells=st.integers(min_value=-1000, max_value=1000),
+        max_cells=st.integers(min_value=-1000, max_value=1000),
         n_modalities=st.integers(min_value=0),
     )
     def test_cell_count_filter(
@@ -57,8 +57,8 @@ class TestCellCountFilter(TestBase):
         adata: AnnData,
         inplace: bool,
         enforce: bool,
-        min_n_obs: int,
-        max_n_obs: int,
+        min_cells: int,
+        max_cells: int,
         n_modalities: int,
     ):
         n_obs, n_vars = adata.shape
@@ -70,11 +70,11 @@ class TestCellCountFilter(TestBase):
         }
 
         n_vars_final = self._get_n_vars_final(
-            adata, modalities_to_filter, min_n_obs, max_n_obs
+            adata, modalities_to_filter, min_cells, max_cells
         )
 
         cell_count_filter = CellCountFilter(
-            inplace=inplace, enforce=enforce, min_n_obs=min_n_obs, max_n_obs=max_n_obs
+            inplace=inplace, enforce=enforce, min_cells=min_cells, max_cells=max_cells
         )
 
         if inplace:

--- a/scvelo/preprocessing/tests/test_filter.py
+++ b/scvelo/preprocessing/tests/test_filter.py
@@ -1,0 +1,93 @@
+import hypothesis.strategies as st
+from hypothesis import given
+
+import numpy as np
+
+from anndata import AnnData
+
+from scvelo.core import get_modality
+from scvelo.core.tests import get_adata, TestBase
+from scvelo.preprocessing._filter import CellCountFilter
+
+
+# TODO: Generalize test to test keyword `shared_counts`
+# TODO: Decouple function `_get_n_vars_final` as it is the same for
+# `TestGeneCountFilter`
+class TestCellCountFilter(TestBase):
+    def _get_n_vars_final(self, adata, modalities_to_filter, min_n_obs, max_n_obs):
+        n_vars_final = {
+            key: ((val.sum(axis=0) >= min_n_obs) & (val.sum(axis=0) <= max_n_obs)).sum()
+            for key, val in modalities_to_filter.items()
+            if key in adata.obsm
+        }
+
+        x_or_layers = {
+            key: val
+            for key, val in modalities_to_filter.items()
+            if (key == "X" or key in adata.layers)
+        }
+        final_counts = np.sum(
+            list(
+                map(
+                    np.all,
+                    zip(
+                        *[
+                            (val.sum(axis=0) >= min_n_obs)
+                            & (val.sum(axis=0) <= max_n_obs)
+                            for key, val in x_or_layers.items()
+                        ]
+                    ),
+                )
+            )
+        )
+        n_vars_final.update({key: final_counts for key in x_or_layers})
+
+        return n_vars_final
+
+    @given(
+        adata=get_adata(),
+        inplace=st.booleans(),
+        enforce=st.booleans(),
+        min_n_obs=st.integers(min_value=-1000, max_value=1000),
+        max_n_obs=st.integers(min_value=-1000, max_value=1000),
+        n_modalities=st.integers(min_value=0),
+    )
+    def test_cell_count_filter(
+        self,
+        adata: AnnData,
+        inplace: bool,
+        enforce: bool,
+        min_n_obs: int,
+        max_n_obs: int,
+        n_modalities: int,
+    ):
+        n_obs, n_vars = adata.shape
+
+        modalities_to_filter = self._subset_modalities(adata, n_modalities)
+        modalities_to_filter = {
+            modality: get_modality(adata=adata, modality=modality) > 0
+            for modality in modalities_to_filter
+        }
+
+        n_vars_final = self._get_n_vars_final(
+            adata, modalities_to_filter, min_n_obs, max_n_obs
+        )
+
+        cell_count_filter = CellCountFilter(
+            inplace=inplace, enforce=enforce, min_n_obs=min_n_obs, max_n_obs=max_n_obs
+        )
+
+        if inplace:
+            cell_count_filter.transform(adata, modalities=modalities_to_filter)
+        else:
+            adata = cell_count_filter.transform(adata, modalities=modalities_to_filter)
+
+        assert adata.n_obs == n_obs
+        assert set(
+            [
+                "initial_size" if modality == "X" else f"initial_size_{modality}"
+                for modality in modalities_to_filter
+            ]
+        ).issubset(adata.obs.columns)
+        for modality in modalities_to_filter:
+            assert get_modality(adata, modality).shape[1] == n_vars_final[modality]

--- a/scvelo/preprocessing/tests/test_filter.py
+++ b/scvelo/preprocessing/tests/test_filter.py
@@ -7,7 +7,7 @@ from anndata import AnnData
 
 from scvelo.core import get_modality
 from scvelo.core.tests import get_adata, TestBase
-from scvelo.preprocessing._filter import CellCountFilter
+from scvelo.preprocessing._filter import CellCountFilter, GeneCountFilter
 
 
 # TODO: Generalize test to test keyword `shared_counts`
@@ -81,6 +81,93 @@ class TestCellCountFilter(TestBase):
             cell_count_filter.transform(adata, modalities=modalities_to_filter)
         else:
             adata = cell_count_filter.transform(adata, modalities=modalities_to_filter)
+
+        assert adata.n_obs == n_obs
+        assert set(
+            [
+                "initial_size" if modality == "X" else f"initial_size_{modality}"
+                for modality in modalities_to_filter
+            ]
+        ).issubset(adata.obs.columns)
+        for modality in modalities_to_filter:
+            assert get_modality(adata, modality).shape[1] == n_vars_final[modality]
+
+
+# TODO: Generalize test to test keyword `shared_counts`
+# TODO: Decouple function `_get_n_vars_final` as it is the same for
+# `TestCellCountFilter`
+class TestGeneCountFilter(TestBase):
+    def _get_n_vars_final(self, adata, modalities_to_filter, min_counts, max_counts):
+        n_vars_final = {
+            key: (
+                (val.sum(axis=0) >= min_counts) & (val.sum(axis=0) <= max_counts)
+            ).sum()
+            for key, val in modalities_to_filter.items()
+            if key in adata.obsm
+        }
+
+        x_or_layers = {
+            key: val
+            for key, val in modalities_to_filter.items()
+            if (key == "X" or key in adata.layers)
+        }
+        final_counts = np.sum(
+            list(
+                map(
+                    np.all,
+                    zip(
+                        *[
+                            (val.sum(axis=0) >= min_counts)
+                            & (val.sum(axis=0) <= max_counts)
+                            for key, val in x_or_layers.items()
+                        ]
+                    ),
+                )
+            )
+        )
+        n_vars_final.update({key: final_counts for key in x_or_layers})
+
+        return n_vars_final
+
+    @given(
+        adata=get_adata(),
+        inplace=st.booleans(),
+        enforce=st.booleans(),
+        min_counts=st.integers(min_value=-1000, max_value=1000),
+        max_counts=st.integers(min_value=-1000, max_value=1000),
+        n_modalities=st.integers(min_value=0),
+    )
+    def test_gene_count_filter(
+        self,
+        adata: AnnData,
+        inplace: bool,
+        enforce: bool,
+        min_counts: int,
+        max_counts: int,
+        n_modalities: int,
+    ):
+        n_obs, n_vars = adata.shape
+
+        modalities_to_filter = self._subset_modalities(adata, n_modalities)
+        modalities_to_filter = {
+            modality: get_modality(adata=adata, modality=modality)
+            for modality in modalities_to_filter
+        }
+
+        n_vars_final = self._get_n_vars_final(
+            adata, modalities_to_filter, min_counts, max_counts
+        )
+
+        gene_count_filter = GeneCountFilter(
+            inplace=inplace,
+            enforce=enforce,
+            min_counts=min_counts,
+            max_counts=max_counts,
+        )
+        if inplace:
+            gene_count_filter.transform(adata, modalities=modalities_to_filter)
+        else:
+            adata = gene_count_filter.transform(adata, modalities=modalities_to_filter)
 
         assert adata.n_obs == n_obs
         assert set(


### PR DESCRIPTION
## New

* Adds base class `ScveloBase`.
* Adds `preprocessing/_preprocessing_base.py` to host any base code for preprocessing. The implemented classes so far ar `PreprocessingBase`, `FilterBase` and `CountFilterBase`.
* Adds `preprocessing/_filter.py` with classes `CellCountFilter` and `GeneCountFilter`.
* Adds unit tests for implemented classes.

Example usage to filter variables in `X` and `unspliced` expressed in less than 5 observations:

```python
from scvelo.preprocessing._filter import CellCountFilter

cc_filter = CellCountFilter(min_n_obs=5)
cc_filter.transform(adata, modalities=["X", "unspliced"])
```

The base class `PreprocessingBase` provides the necessary methods to check if modalities are normalized, to set initial counts if they have not been set, exclude modalities from a preprocessing step, etc. Classes inheriting from it and actually implementing a preprocessing step only need to implement the `_transform` method and potentially `_update_modalities` if modalities can be excluded from the step (e.g. if they not normalized but are required to be).