### PR TITLE
Allow umap-learn>=0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scanpy>=1.5           # adapt to new anndata attributes (v1.5)
 loompy>=2.0.12        # introduced sparsity support (v2.0.12)
 
 # for computing neighbor graph connectivities
-umap-learn>=0.3.10, <0.5    # removed numba warnings (v0.3.10)
+umap-learn>=0.3.10    # removed numba warnings (v0.3.10)
 
 # standard requirements for data analysis
 numba>=0.41.0,<0.53.0


### PR DESCRIPTION
## Changes

* Allow versions `umap-learn>=0.5.0`.

## Related issues

Closes theislab/scanpy#1799.