### PR TITLE
Fix import of literal for Python>=3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+typing_extensions
+
 # main requirements for single-cell analysis
 anndata>=0.7.5        # compatible with h5py v3.0 (v0.7.5)
 scanpy>=1.5           # adapt to new anndata attributes (v1.5)


### PR DESCRIPTION
## Bug fixes

* Adds `typing_extensions` to `requirements.txt`. This allows importing `Literal` in `python>=3.8`.

## Related issues

Closes #443.