### PR TITLE
Update `recover_dynamics` docs

### DIFF
--- a/scvelo/tools/dynamical_model.py
+++ b/scvelo/tools/dynamical_model.py
@@ -373,7 +373,9 @@ def recover_dynamics(
     data: :class:`~anndata.AnnData`
         Annotated data matrix.
     var_names: `str`,  list of `str` (default: `'velocity_genes'`)
-        Names of variables/genes to use for the fitting.
+        Names of variables/genes to use for the fitting. If `var_names='velocity_genes'`
+        but there is no column `'velocity_genes'` in `adata.var`, velocity genes are
+        estimated using the steady state model.
     n_top_genes: `int` or `None` (default: `None`)
         Number of top velocity genes to use for the dynamical model.
     max_iter:`int` (default: `10`)

--- a/scvelo/tools/dynamical_model.py
+++ b/scvelo/tools/dynamical_model.py
@@ -372,7 +372,7 @@ def recover_dynamics(
     ---------
     data: :class:`~anndata.AnnData`
         Annotated data matrix.
-    var_names: `str`,  list of `str` (default: `'velocity_genes`)
+    var_names: `str`,  list of `str` (default: `'velocity_genes'`)
         Names of variables/genes to use for the fitting.
     n_top_genes: `int` or `None` (default: `None`)
         Number of top velocity genes to use for the dynamical model.


### PR DESCRIPTION
## Changes

* Fix typo.
* Add explanation on how variable genes are determined if not yet defined through a column `velocity_genes` in `adata.var`.

## Related issues

Closes #497.
