### PR TITLE
Fix and refactor `filter_genes`

### DIFF
--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -12,7 +12,7 @@ from ._anndata import (
     set_modality,
     show_proportions,
 )
-from ._arithmetic import clipped_log, invert, prod_sum, sum
+from ._arithmetic import clipped_log, invert, multiply, prod_sum, sum
 from ._linear_models import LinearRegression
 from ._metrics import l2_norm
 from ._models import SplicingDynamics
@@ -33,6 +33,7 @@ __all__ = [
     "make_dense",
     "make_sparse",
     "merge",
+    "multiply",
     "parallelize",
     "prod_sum",
     "set_initial_size",

--- a/scvelo/core/_arithmetic.py
+++ b/scvelo/core/_arithmetic.py
@@ -49,6 +49,32 @@ def invert(x: ndarray) -> ndarray:
     return x_inv
 
 
+def multiply(
+    a: Union[ndarray, spmatrix], b: Union[ndarray, spmatrix]
+) -> Union[ndarray, spmatrix]:
+    """Point-wise multiplication of arrays or sparse matrices.
+
+    Arguments
+    ---------
+    a
+        First array/sparse matrix.
+    b
+        Second array/sparse matrix.
+
+    Returns
+    -------
+    Union[ndarray, spmatrix]
+        Point-wise product of `a` and `b`.
+    """
+
+    if issparse(a):
+        return a.multiply(b)
+    elif issparse(b):
+        return b.multiply(a)
+    else:
+        return a * b
+
+
 def prod_sum(
     a1: Union[ndarray, spmatrix], a2: Union[ndarray, spmatrix], axis: Optional[int]
 ) -> ndarray:

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -11,6 +11,7 @@ from scvelo import logging as logg
 from scvelo.core import cleanup as _cleanup
 from scvelo.core import get_initial_size as _get_initial_size
 from scvelo.core import get_size as _get_size
+from scvelo.core import multiply
 from scvelo.core import set_initial_size as _set_initial_size
 from scvelo.core import show_proportions as _show_proportions
 from scvelo.core import sum
@@ -233,14 +234,9 @@ def filter_genes(
             X = adata.layers[layer]
         else:  # shared counts/cells
             Xs, Xu = adata.layers["spliced"], adata.layers["unspliced"]
-            nonzeros = (
-                (Xs > 0).multiply(Xu > 0) if issparse(Xs) else (Xs > 0) * (Xu > 0)
-            )
-            X = (
-                nonzeros.multiply(Xs) + nonzeros.multiply(Xu)
-                if issparse(nonzeros)
-                else nonzeros * (Xs + Xu)
-            )
+
+            nonzeros = multiply(Xs > 0, Xu > 0)
+            X = multiply(nonzeros, Xs) + multiply(nonzeros, Xu)
 
         gene_subset = np.ones(adata.n_vars, dtype=bool)
 


### PR DESCRIPTION
## Bug fixes

* `filter_genes` now works with `adata.layers['unspliced']` being sparse and `adata.layers['spliced']` dense.

## New

* Adds function `multiply` for element-wise multiplication of arrays and sparse matrices

## Changes

* Refactors `filter_genes` to make use of `multiply` and fix #533.

## Related issues

Closes #533.