### PR TITLE
Add unit tests for cleanup

### DIFF
--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -10,6 +10,7 @@ from anndata import AnnData
 
 from scvelo.core import (
     clean_obs_names,
+    cleanup,
     get_modality,
     make_dense,
     make_sparse,
@@ -61,6 +62,107 @@ class TestCleanObsNames:
         assert (adata.obs_names == obs_names_cleaned).all()
         assert "sample_batch" in adata.obs
         assert adata.obs["sample_batch"].str.startswith("sample").all()
+
+
+class TestCleanup(TestBase):
+    @given(adata=get_adata(), copy=st.booleans())
+    def test_cleanup_all(self, adata: AnnData, copy: bool):
+        returned_adata = cleanup(adata, clean="all", copy=copy)
+
+        if copy:
+            assert isinstance(returned_adata, AnnData)
+            adata = returned_adata
+        else:
+            assert returned_adata is None
+
+        assert len(adata.layers) == 0
+        assert len(adata.uns) == 0
+        assert len(adata.obs.columns) == 0
+        assert len(adata.var.columns) == 0
+
+    @given(adata=get_adata(), copy=st.booleans())
+    def test_cleanup_default_clean_w_random_adata(self, adata: AnnData, copy: bool):
+        n_obs_cols = len(adata.obs.columns)
+        n_var_cols = len(adata.var.columns)
+        n_uns_slots = len(adata.uns)
+
+        returned_adata = cleanup(adata)
+        assert returned_adata is None
+
+        assert len(adata.layers) == 0
+        assert len(adata.uns) == n_uns_slots
+        assert len(adata.obs.columns) == n_obs_cols
+        assert len(adata.var.columns) == n_var_cols
+
+    @given(
+        adata=get_adata(layer_keys=["unspliced", "spliced", "Ms", "Mu", "random"]),
+        copy=st.booleans(),
+    )
+    def test_cleanup_default_clean(self, adata: AnnData, copy: bool):
+        n_obs_cols = len(adata.obs.columns)
+        n_var_cols = len(adata.var.columns)
+        n_uns_slots = len(adata.uns)
+
+        returned_adata = cleanup(adata, copy=copy)
+
+        if copy:
+            assert isinstance(returned_adata, AnnData)
+            adata = returned_adata
+        else:
+            assert returned_adata is None
+
+        assert len(adata.layers) == 4
+        assert len(adata.uns) == n_uns_slots
+        assert len(adata.obs.columns) == n_obs_cols
+        assert len(adata.var.columns) == n_var_cols
+
+    @given(
+        adata=get_adata(),
+        copy=st.booleans(),
+        n_modalities=st.integers(min_value=0),
+        n_cols=st.integers(min_value=0),
+    )
+    def test_cleanup_some(
+        self, adata: AnnData, copy: bool, n_modalities: int, n_cols: int
+    ):
+        layers_to_keep = self._subset_modalities(
+            adata,
+            n_modalities,
+            from_obsm=False,
+        )
+        obs_cols_to_keep = self._subset_columns(adata, n_cols=n_cols, from_var=False)
+        var_cols_to_keep = self._subset_columns(adata, n_cols=n_cols, from_obs=False)
+
+        # Update in case adata.layers, adata.obs, adata.var share same keys
+        layers_to_keep += set(adata.layers).intersection(obs_cols_to_keep)
+        layers_to_keep += set(adata.layers).intersection(var_cols_to_keep)
+
+        obs_cols_to_keep += set(adata.obs.columns).intersection(var_cols_to_keep)
+        obs_cols_to_keep += set(adata.obs.columns).intersection(layers_to_keep)
+
+        var_cols_to_keep += set(adata.var.columns).intersection(obs_cols_to_keep)
+        obs_cols_to_keep += set(adata.var.columns).intersection(layers_to_keep)
+
+        returned_adata = cleanup(
+            adata,
+            keep=layers_to_keep + obs_cols_to_keep + var_cols_to_keep,
+            clean="all",
+            copy=copy,
+        )
+
+        if copy:
+            assert isinstance(returned_adata, AnnData)
+            adata = returned_adata
+        else:
+            assert returned_adata is None
+
+        # Distinction is needed since `self._subset_modalities` always includes `"X"`
+        if "X" in adata.layers:
+            assert set(adata.layers.keys()) == set(layers_to_keep)
+        else:
+            assert set(adata.layers.keys()) == set(layers_to_keep).difference({"X"})
+        assert set(adata.obs.columns) == set(obs_cols_to_keep)
+        assert set(adata.var.columns) == set(var_cols_to_keep)
 
 
 class TestGetModality(TestBase):

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -271,6 +271,22 @@ class TestBase:
             modalities += list(adata.obsm.keys())
         return random.sample(modalities, min(len(modalities), n_modalities))
 
+    def _subset_columns(
+        self,
+        adata: AnnData,
+        n_cols: int,
+        from_obs: bool = True,
+        from_var: bool = True,
+    ):
+        """Subset columns of an AnnData object in `obs` and `var` slots."""
+
+        columns = []
+        if from_obs:
+            columns += list(adata.obs.columns)
+        if from_var:
+            columns += list(adata.var.columns)
+        return random.sample(columns, min(len(columns), n_cols))
+
     def _convert_to_float(self, adata: AnnData):
         """Convert AnnData entries in `layer` and `obsm` into floats."""
 


### PR DESCRIPTION
## New

* Adds method `_subset_columns` to `TestBase` to sample from `adata.obs` or `adata.var`.
* Adds `TestCleanup` with unit tests for `scvelo/core/_anndata.py::cleanup`.

## Related issues

Closes #547.