### PR TITLE
Fix TestCleanup::test_cleanup_some

### DIFF
--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -141,7 +141,7 @@ class TestCleanup(TestBase):
         obs_cols_to_keep += set(adata.obs.columns).intersection(layers_to_keep)
 
         var_cols_to_keep += set(adata.var.columns).intersection(obs_cols_to_keep)
-        obs_cols_to_keep += set(adata.var.columns).intersection(layers_to_keep)
+        var_cols_to_keep += set(adata.var.columns).intersection(layers_to_keep)
 
         returned_adata = cleanup(
             adata,


### PR DESCRIPTION
## Bug fixes

* Fixes definition of columns to keep in `adata.var`.

## Related issues

Closes #549.