### PR TITLE
Refactor `cleanup`

### DIFF
--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -103,7 +103,7 @@ def clean_obs_names(
         return adata
 
 
-@deprecated_arg_names({"data": "adata"})
+@deprecated_arg_names({"data": "adata", "copy": "inplace"})
 def cleanup(
     adata: AnnData,
     clean: Union[
@@ -111,7 +111,7 @@ def cleanup(
         List[Literal["layers", "obs", "var", "uns"]],
     ] = "layers",
     keep: Optional[Union[str, List[str]]] = None,
-    copy: bool = False,
+    inplace: bool = True,
 ) -> Optional[AnnData]:
     """Delete not needed attributes.
 
@@ -123,8 +123,8 @@ def cleanup(
         Which attributes to consider for freeing memory.
     keep
         Which attributes to keep.
-    copy
-        Return a copy instead of writing to adata.
+    inplace
+        Whether to update `adata` inplace or not.
 
     Returns
     -------
@@ -132,7 +132,7 @@ def cleanup(
         Returns or updates `adata` with selection of attributes kept.
     """
 
-    if copy:
+    if not inplace:
         adata = adata.copy()
     verify_dtypes(adata)
 
@@ -154,7 +154,8 @@ def cleanup(
             if value not in keep:
                 del getattr(adata, ann)[value]
 
-    return adata if copy else None
+    if not inplace:
+        return adata
 
 
 def get_df(

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -139,7 +139,7 @@ def cleanup(
     keep = list([keep] if isinstance(keep, str) else {} if keep is None else keep)
     keep.extend(["spliced", "unspliced", "Ms", "Mu", "clusters", "neighbors"])
 
-    ann_dict = {
+    attributes_to_remove = {
         "obs": adata.obs_keys(),
         "var": adata.var_keys(),
         "uns": adata.uns_keys(),
@@ -147,12 +147,16 @@ def cleanup(
     }
 
     if "all" not in clean:
-        ann_dict = {ann: values for (ann, values) in ann_dict.items() if ann in clean}
+        attributes_to_remove = {
+            attr: attr_keys
+            for (attr, attr_keys) in attributes_to_remove.items()
+            if attr in clean
+        }
 
-    for (ann, values) in ann_dict.items():
-        for value in values:
-            if value not in keep:
-                del getattr(adata, ann)[value]
+    for (attr, attr_keys) in attributes_to_remove.items():
+        for key in attr_keys:
+            if key not in keep:
+                del getattr(adata, attr)[key]
 
     if not inplace:
         return adata

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -103,8 +103,9 @@ def clean_obs_names(
         return adata
 
 
+@deprecated_arg_names({"data": "adata"})
 def cleanup(
-    data: AnnData,
+    adata: AnnData,
     clean: Union[
         Literal["layers", "obs", "var", "uns"],
         List[Literal["layers", "obs", "var", "uns"]],
@@ -116,7 +117,7 @@ def cleanup(
 
     Arguments
     ---------
-    data
+    adata
         Annotated data matrix.
     clean
         Which attributes to consider for freeing memory.
@@ -131,7 +132,8 @@ def cleanup(
         Returns or updates `adata` with selection of attributes kept.
     """
 
-    adata = data.copy() if copy else data
+    if copy:
+        adata = adata.copy()
     verify_dtypes(adata)
 
     keep = list([keep] if isinstance(keep, str) else {} if keep is None else keep)

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -107,7 +107,7 @@ def clean_obs_names(
 def cleanup(
     adata: AnnData,
     clean: Union[
-        Literal["layers", "obs", "var", "uns"],
+        Literal["layers", "obs", "var", "uns", "all"],
         List[Literal["layers", "obs", "var", "uns"]],
     ] = "layers",
     keep: Optional[Union[str, List[str]]] = None,

--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -67,7 +67,7 @@ class TestCleanObsNames:
 class TestCleanup(TestBase):
     @given(adata=get_adata(), copy=st.booleans())
     def test_cleanup_all(self, adata: AnnData, copy: bool):
-        returned_adata = cleanup(adata, clean="all", copy=copy)
+        returned_adata = cleanup(adata=adata, clean="all", copy=copy)
 
         if copy:
             assert isinstance(returned_adata, AnnData)
@@ -86,7 +86,7 @@ class TestCleanup(TestBase):
         n_var_cols = len(adata.var.columns)
         n_uns_slots = len(adata.uns)
 
-        returned_adata = cleanup(adata)
+        returned_adata = cleanup(adata=adata)
         assert returned_adata is None
 
         assert len(adata.layers) == 0
@@ -103,7 +103,7 @@ class TestCleanup(TestBase):
         n_var_cols = len(adata.var.columns)
         n_uns_slots = len(adata.uns)
 
-        returned_adata = cleanup(adata, copy=copy)
+        returned_adata = cleanup(adata=adata, copy=copy)
 
         if copy:
             assert isinstance(returned_adata, AnnData)
@@ -144,7 +144,7 @@ class TestCleanup(TestBase):
         var_cols_to_keep += set(adata.var.columns).intersection(layers_to_keep)
 
         returned_adata = cleanup(
-            adata,
+            adata=adata,
             keep=layers_to_keep + obs_cols_to_keep + var_cols_to_keep,
             clean="all",
             copy=copy,

--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -65,11 +65,11 @@ class TestCleanObsNames:
 
 
 class TestCleanup(TestBase):
-    @given(adata=get_adata(), copy=st.booleans())
-    def test_cleanup_all(self, adata: AnnData, copy: bool):
-        returned_adata = cleanup(adata=adata, clean="all", copy=copy)
+    @given(adata=get_adata(), inplace=st.booleans())
+    def test_cleanup_all(self, adata: AnnData, inplace: bool):
+        returned_adata = cleanup(adata=adata, clean="all", inplace=inplace)
 
-        if copy:
+        if not inplace:
             assert isinstance(returned_adata, AnnData)
             adata = returned_adata
         else:
@@ -80,14 +80,18 @@ class TestCleanup(TestBase):
         assert len(adata.obs.columns) == 0
         assert len(adata.var.columns) == 0
 
-    @given(adata=get_adata(), copy=st.booleans())
-    def test_cleanup_default_clean_w_random_adata(self, adata: AnnData, copy: bool):
+    @given(adata=get_adata(), inplace=st.booleans())
+    def test_cleanup_default_clean_w_random_adata(self, adata: AnnData, inplace: bool):
         n_obs_cols = len(adata.obs.columns)
         n_var_cols = len(adata.var.columns)
         n_uns_slots = len(adata.uns)
 
-        returned_adata = cleanup(adata=adata)
-        assert returned_adata is None
+        returned_adata = cleanup(adata=adata, inplace=inplace)
+        if not inplace:
+            assert isinstance(returned_adata, AnnData)
+            adata = returned_adata
+        else:
+            assert returned_adata is None
 
         assert len(adata.layers) == 0
         assert len(adata.uns) == n_uns_slots
@@ -96,16 +100,16 @@ class TestCleanup(TestBase):
 
     @given(
         adata=get_adata(layer_keys=["unspliced", "spliced", "Ms", "Mu", "random"]),
-        copy=st.booleans(),
+        inplace=st.booleans(),
     )
-    def test_cleanup_default_clean(self, adata: AnnData, copy: bool):
+    def test_cleanup_default_clean(self, adata: AnnData, inplace: bool):
         n_obs_cols = len(adata.obs.columns)
         n_var_cols = len(adata.var.columns)
         n_uns_slots = len(adata.uns)
 
-        returned_adata = cleanup(adata=adata, copy=copy)
+        returned_adata = cleanup(adata=adata, inplace=inplace)
 
-        if copy:
+        if not inplace:
             assert isinstance(returned_adata, AnnData)
             adata = returned_adata
         else:
@@ -118,12 +122,12 @@ class TestCleanup(TestBase):
 
     @given(
         adata=get_adata(),
-        copy=st.booleans(),
+        inplace=st.booleans(),
         n_modalities=st.integers(min_value=0),
         n_cols=st.integers(min_value=0),
     )
     def test_cleanup_some(
-        self, adata: AnnData, copy: bool, n_modalities: int, n_cols: int
+        self, adata: AnnData, inplace: bool, n_modalities: int, n_cols: int
     ):
         layers_to_keep = self._subset_modalities(
             adata,
@@ -147,10 +151,10 @@ class TestCleanup(TestBase):
             adata=adata,
             keep=layers_to_keep + obs_cols_to_keep + var_cols_to_keep,
             clean="all",
-            copy=copy,
+            inplace=inplace,
         )
 
-        if copy:
+        if not inplace:
             assert isinstance(returned_adata, AnnData)
             adata = returned_adata
         else:


### PR DESCRIPTION
## Changes

* Renames arguments of `cleanup`. `data` is superseded by `adata`, `copy` by `inplace`.
* Variable names in `cleanup` are updated to be more informative.

## Related issues

Closes #551.