### PR TITLE
Allow `None` as `modality` in `get_modality`

### DIFF
--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -376,7 +376,7 @@ def get_initial_size(
         return None
 
 
-def get_modality(adata: AnnData, modality: str) -> Union[ndarray, spmatrix]:
+def get_modality(adata: AnnData, modality: Optional[str]) -> Union[ndarray, spmatrix]:
     """Extract data of one modality.
 
     Arguments
@@ -392,7 +392,7 @@ def get_modality(adata: AnnData, modality: str) -> Union[ndarray, spmatrix]:
         Retrieved modality from :class:`~anndata.AnnData` object.
     """
 
-    if modality == "X":
+    if modality in ["X", None]:
         return adata.X
     elif modality in adata.layers.keys():
         return adata.layers[modality]

--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -244,6 +244,12 @@ class TestGetModality(TestBase):
         else:
             assert_array_equal(adata.obsm[modality_to_get], modality_retrieved)
 
+    @given(adata=get_adata())
+    def test_modality_equals_none(self, adata: AnnData):
+        modality_retrieved = get_modality(adata=adata, modality=None)
+
+        assert_array_equal(adata.X, modality_retrieved)
+
 
 class TestGetSize(TestBase):
     @given(adata=get_adata())


### PR DESCRIPTION
## Changes

* Supports passing `None` for `modality` in `scvelo.core._anndata.py::get_modality`.

## New

* Adds a unit test to `TestGetModality` to verify using `modality=None` returns correct data.

## Related issues

Closes #566.