### PR TITLE
Refactor and generalize `get_size`

### DIFF
--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -417,7 +417,7 @@ def get_size(adata: AnnData, modality: Optional[str] = None) -> ndarray:
     Returns
     -------
     np.ndarray
-        Initial counts per observation in the specified modality.
+        Counts per observation in the specified modality.
     """
 
     X = get_modality(adata=adata, modality=modality)

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -404,23 +404,24 @@ def get_modality(adata: AnnData, modality: Optional[str]) -> Union[ndarray, spma
 
 
 # TODO: Generalize to arbitray modality
-def get_size(adata: AnnData, layer: Optional[str] = None) -> ndarray:
-    """Get counts per observation in a layer.
+@deprecated_arg_names({"layer": "modality"})
+def get_size(adata: AnnData, modality: Optional[str] = None) -> ndarray:
+    """Get counts per observation in a modality.
 
     Arguments
     ---------
     adata
         Annotated data matrix.
-    layer
-        Name of later for which to retrieve initial size.
+    modality
+        Name of modality for which to retrieve size.
 
     Returns
     -------
     np.ndarray
-        Initial counts per observation in the specified layer.
+        Initial counts per observation in the specified modality.
     """
 
-    X = adata.X if layer is None else adata.layers[layer]
+    X = adata.X if modality is None else adata.layers[modality]
     return sum(X, axis=1)
 
 

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -403,7 +403,6 @@ def get_modality(adata: AnnData, modality: Optional[str]) -> Union[ndarray, spma
             return adata.obsm[modality]
 
 
-# TODO: Generalize to arbitray modality
 @deprecated_arg_names({"layer": "modality"})
 def get_size(adata: AnnData, modality: Optional[str] = None) -> ndarray:
     """Get counts per observation in a modality.
@@ -421,7 +420,7 @@ def get_size(adata: AnnData, modality: Optional[str] = None) -> ndarray:
         Initial counts per observation in the specified modality.
     """
 
-    X = adata.X if modality is None else adata.layers[modality]
+    X = get_modality(adata=adata, modality=modality)
     return sum(X, axis=1)
 
 

--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -254,17 +254,19 @@ class TestGetModality(TestBase):
 class TestGetSize(TestBase):
     @given(adata=get_adata())
     def test_get_size(self, adata: AnnData):
-        layer_name = self._subset_modalities(adata, n_modalities=1, from_obsm=False)[0]
+        modality = self._subset_modalities(adata, n_modalities=1, from_obsm=False)[0]
 
-        if layer_name == "X":
-            np.testing.assert_allclose(
-                sum(adata.X, axis=1), get_size(adata=adata, layer=None)
-            )
-        else:
-            np.testing.assert_allclose(
-                sum(adata.layers[layer_name], axis=1),
-                get_size(adata=adata, layer=layer_name),
-            )
+        np.testing.assert_allclose(
+            sum(adata.layers[modality], axis=1),
+            get_size(adata=adata, modality=modality),
+        )
+
+    @given(adata=get_adata())
+    def test_modality_set_to_none(self, adata: AnnData):
+        np.testing.assert_allclose(
+            sum(adata.X, axis=1),
+            get_size(adata=adata, modality=None),
+        )
 
 
 class TestMakeDense(TestBase):

--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -254,10 +254,10 @@ class TestGetModality(TestBase):
 class TestGetSize(TestBase):
     @given(adata=get_adata())
     def test_get_size(self, adata: AnnData):
-        modality = self._subset_modalities(adata, n_modalities=1, from_obsm=False)[0]
+        modality = self._subset_modalities(adata, n_modalities=1)[0]
 
         np.testing.assert_allclose(
-            sum(adata.layers[modality], axis=1),
+            sum(get_modality(adata=adata, modality=modality), axis=1),
             get_size(adata=adata, modality=modality),
         )
 


### PR DESCRIPTION
## Changes

* Renames argument `layer` to `modality`.

## New

* Allows calculating counts per observation for an arbitrary modality, i.e. also from `adata.obsm`.

## Related issues

Closes #568.