### PR TITLE
Fix typo in default layer names

### DIFF
--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -716,7 +716,7 @@ def show_proportions(
     """
 
     if layers is None:
-        layers = ["spliced", "unspliced", "ambigious"]
+        layers = ["spliced", "unspliced", "ambiguous"]
     layers_keys = [key for key in layers if key in adata.layers.keys()]
     counts_layers = [sum(adata.layers[key], axis=1) for key in layers_keys]
     if use_raw:


### PR DESCRIPTION
## Bug fixes

* Fixes typo in default layer names in `scvelo.core._anndata.py::show_proportions` from `ambigious` to `ambiguous`.

## Related issues

Closes #586.