### PR TITLE
Fix `TestGetInitialSize::test_not_existing_modality`

### DIFF
--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -237,7 +237,7 @@ class TestGetInitialSize(TestBase):
         adata=get_adata(
             layer_keys=["unspliced", "spliced", "ambiguous"],
         ),
-        layer=st.text(min_size=1, max_size=5),
+        layer=st.text(min_size=2, max_size=5),
     )
     def test_not_existing_modality(self, adata: AnnData, layer: str):
         initial_size = get_initial_size(adata=adata, layer=layer)


### PR DESCRIPTION
## Bugfixes

* Generate layer names with at least two characters to exclude case `layer='X'`.

## Related issues

Closes #604.