### PR TITLE
Catch error in steady state calculation

### DIFF
--- a/scvelo/core/_models.py
+++ b/scvelo/core/_models.py
@@ -131,7 +131,9 @@ class SplicingDynamics(DynamicsBase):
             Steady state of system.
         """
 
-        if (self.beta > 0) and (self.gamma > 0):
+        if (self.beta <= 0) or (self.gamma <= 0):
+            raise ValueError("Both `beta` and `gamma` need to be strictly positive.")
+        else:
             unspliced = self.alpha / self.beta
             spliced = self.alpha / self.gamma
 

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -88,3 +88,35 @@ class TestSplicingDynamics:
         )
 
         assert np.allclose(numerical_solution, exact_solution)
+
+    @given(
+        alpha=st.floats(),
+        beta=st.floats(max_value=0, allow_infinity=False, allow_nan=False),
+        gamma=st.floats(max_value=0, allow_infinity=False, allow_nan=False),
+        initial_state=arrays(
+            float,
+            shape=st.integers(min_value=2, max_value=2),
+            elements=st.floats(
+                min_value=-1e3, max_value=1e3, allow_infinity=False, allow_nan=False
+            ),
+        ),
+        with_keys=st.booleans(),
+        stacked=st.booleans(),
+    )
+    def test_steady_state_not_defined(
+        self,
+        alpha: float,
+        beta: float,
+        gamma: float,
+        initial_state: ndarray,
+        with_keys: bool,
+        stacked: bool,
+    ):
+        dm = SplicingDynamics(
+            alpha=alpha, beta=beta, gamma=gamma, initial_state=initial_state
+        )
+
+        with pytest.raises(
+            ValueError, match=("Both `beta` and `gamma` need to be strictly positive.")
+        ):
+            _ = dm.get_steady_states(stacked=stacked, with_keys=with_keys)


### PR DESCRIPTION
## Changes

* Catch non-positive parameter values and raise `ValueError`

## New

* Add unit test `TestSplicingDynamics.test_steady_state_not_defined` to raising of `ValueError`.

## Related issues

Closes #613.