### PR TITLE
Update AnnData generation for testing

### DIFF
--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -195,11 +195,7 @@ class TestCleanup(TestBase):
         else:
             assert returned_adata is None
 
-        # Distinction is needed since `self._subset_modalities` always includes `"X"`
-        if "X" in adata.layers:
-            assert set(adata.layers.keys()) == set(layers_to_keep)
-        else:
-            assert set(adata.layers.keys()) == set(layers_to_keep).difference({"X"})
+        assert set(adata.layers.keys()) == set(layers_to_keep).difference({"X"})
         assert set(adata.obs.columns) == set(obs_cols_to_keep)
         assert set(adata.var.columns) == set(var_cols_to_keep)
 
@@ -915,7 +911,7 @@ class TestSetInitialSize(TestBase):
 
         set_initial_size(adata=adata, layers=layers)
 
-        if "X" in layers and "X" not in adata.layers:
+        if "X" in layers:
             assert (
                 sum(
                     adata.obs.columns.isin(

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -274,6 +274,9 @@ class TestAdataGeneration:
     @given(adata=get_adata(max_obs=5, max_vars=5))
     def test_default_adata_generation(self, adata: AnnData):
         assert type(adata) is AnnData
+        assert "X" not in adata.layers
+        assert "X" not in adata.obsm
+        assert "X" not in adata.varm
 
     @given(adata=get_adata(max_obs=5, max_vars=5, sparse_entries=True))
     def test_sparse_adata_generation(self, adata: AnnData):

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -158,7 +158,15 @@ def get_adata(
 
     layers = draw(
         st.dictionaries(
-            st.text(min_size=1) if layer_keys is None else st.sampled_from(layer_keys),
+            st.text(
+                st.characters(
+                    blacklist_categories=("Cs",),
+                    blacklist_characters=("X"),
+                ),
+                min_size=1,
+            )
+            if layer_keys is None
+            else st.sampled_from(layer_keys),
             arrays(
                 dtype=int,
                 elements=st.integers(min_value=0, max_value=1e2),
@@ -171,7 +179,15 @@ def get_adata(
 
     obsm = draw(
         st.dictionaries(
-            st.text(min_size=1) if obsm_keys is None else st.sampled_from(obsm_keys),
+            st.text(
+                st.characters(
+                    blacklist_categories=("Cs",),
+                    blacklist_characters=("X"),
+                ),
+                min_size=1,
+            )
+            if obsm_keys is None
+            else st.sampled_from(obsm_keys),
             arrays(
                 dtype=int,
                 elements=st.integers(min_value=0, max_value=1e2),
@@ -187,7 +203,15 @@ def get_adata(
 
     varm = draw(
         st.dictionaries(
-            st.text(min_size=1) if varm_keys is None else st.sampled_from(varm_keys),
+            st.text(
+                st.characters(
+                    blacklist_categories=("Cs",),
+                    blacklist_characters=("X"),
+                ),
+                min_size=1,
+            )
+            if varm_keys is None
+            else st.sampled_from(varm_keys),
             arrays(
                 dtype=int,
                 elements=st.integers(min_value=0, max_value=1e2),


### PR DESCRIPTION
## Changes

* Update strategy `get_adata` to exclude the key `"X"` in `.layers`, `.obsm`, `.varm`.
* Remove redundant statement in unit tests resulting from this update.

## Related issues

Closes #784.