### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           pip install hypothesis pytest pytest-cov
       - name: Unit tests
         timeout-minutes: 60
-        run: python -m pytest --ignore=tests/datasets/test_datasets.py --cov=scvelo -vv
+        run: python -m pytest --durations=25 --ignore=tests/datasets/test_datasets.py --cov=scvelo -vv
 
   test-dataset-downloads:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,21 @@ jobs:
           pip install hypothesis pytest pytest-cov
       - name: Unit tests
         timeout-minutes: 60
-        run: python -m pytest --cov=scvelo -vv
+        run: python -m pytest --ignore=tests/datasets/test_datasets.py --cov=scvelo -vv
+
+  test-dataset-downloads:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install pytest pytest-cov
+      - name: Test dataset downloads
+        timeout-minutes: 60
+        run: python -m pytest tests/datasets/test_datasets.py -vv

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import Optional
 
 import pytest
@@ -16,6 +17,10 @@ def dentategyrus_adata(tmpdir_factory):
     return path_to_file
 
 
+@pytest.mark.skipif(
+    sys.version_info[:2] != (3, 8) or sys.platform != "linux",
+    reason="Limit number of downloads to speed up testing.",
+)
 class TestDataSets:
     def test_dentategyrus_adjusted(self, dentategyrus_adata):
         adata = scv.datasets.dentategyrus(file_path=dentategyrus_adata, adjusted=True)


### PR DESCRIPTION
## Changes

* Ignore `tests/datasets/test_datasets.py` in `test` job of CI.
* Add job `test-dataset-downloads` to CI which only runs on `ubuntu-latest` and Python 3.8.
* Skip `test_datasets.py:TestDataSets` if Python version is not 3.8 and OS not Linux.