### PR TITLE
Increase Hypothesis deadline in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: pip install -e '.[dev]'
       - name: Unit tests
         timeout-minutes: 60
-        run: python -m pytest --durations=25 --ignore=tests/datasets/test_datasets.py --cov=scvelo -vv
+        run: python -m pytest --durations=25 --ignore=tests/datasets/test_datasets.py --hypothesis-profile=ci --cov=scvelo -vv
 
   test-dataset-downloads:
     needs: test
@@ -72,7 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
-          pip install pytest pytest-cov
+          pip install hypothesis pytest pytest-cov
       - name: Test dataset downloads
         timeout-minutes: 60
         run: python -m pytest tests/datasets/test_datasets.py -vv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,13 @@
+from datetime import timedelta
+
 import pytest
+from hypothesis import settings
 
 import scanpy as sc
 from anndata import AnnData
+
+settings.register_profile("ci", deadline=timedelta(milliseconds=500))
+
 
 # TODO: Make datasets smaller (less variables)
 _dentategyrus_50obs = sc.read("tests/_data/dentategyrus_50obs.h5ad")


### PR DESCRIPTION
## Changes

* The deadline for tests using Hypothesis is set to 500 milliseconds.

## Related issues

Closes #803.