### PR TITLE
Exclude `pandas==1.4`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ umap-learn>=0.3.10    # removed numba warnings (v0.3.10)
 numba>=0.41.0
 numpy>=1.17           # extension/speedup in .nan_to_num, .exp (v1.17)
 scipy>=1.4.1          # introduced PCA sparsity support (v1.4)
-pandas>=0.23          # merging/sorting extensions (v0.23)
+pandas>=0.23, !=1.4.0 # merging/sorting extensions (v0.23)
 scikit-learn>=0.21.2  # bugfix in .utils.sparsefuncs (v0.21.2)
 matplotlib>=3.3.0     # normalize in pie (v3.3.0)


### PR DESCRIPTION
## Bugfixes

* Prevents failure as reported in #811 

## Related issues

Closes #811.