### PR TITLE
Fix bug with clean_obs_names

### DIFF
--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -47,12 +47,15 @@ class TestCleanObsNames:
     )
     @pytest.mark.parametrize("inplace", (True, False))
     def test_equal_obs_id_length(
-        self, obs_names: List[str], obs_names_cleaned: List[str], inplace: bool
+        self,
+        obs_names: List[str],
+        obs_names_cleaned: List[str],
+        inplace: bool,
     ):
         adata = AnnData(np.eye(3))
         adata.obs_names = obs_names
 
-        _adata = clean_obs_names(adata, inplace=inplace)
+        _adata = clean_obs_names(adata, inplace=inplace, id_length=4)
 
         if inplace:
             assert _adata is None
@@ -75,12 +78,15 @@ class TestCleanObsNames:
     )
     @pytest.mark.parametrize("inplace", (True, False))
     def test_different_obs_id_length(
-        self, obs_names: List[str], obs_names_cleaned: List[str], inplace: bool
+        self,
+        obs_names: List[str],
+        obs_names_cleaned: List[str],
+        inplace: bool,
     ):
         adata = AnnData(np.eye(3))
         adata.obs_names = obs_names
 
-        _adata = clean_obs_names(adata, inplace=inplace)
+        _adata = clean_obs_names(adata, inplace=inplace, id_length=4)
 
         if inplace:
             assert _adata is None
@@ -778,7 +784,7 @@ class TestMerge:
         adata.obs_names = ["sample1_ABCD", "sample2_ABCD", "sample3_DCBA"]
         ldata.obs_names = ["_sample1_ABCD", "_sample2_ABCD", "_sample3_DCBA"]
 
-        returned_adata = merge(adata=adata, ldata=ldata, copy=copy)
+        returned_adata = merge(adata=adata, ldata=ldata, copy=copy, id_length=4)
 
         returned_adata = self._assert_copy_worked(returned_adata, adata, copy)
         self._assert_all_entries_present(returned_adata, adata, ldata)

--- a/tests/core/test_anndata.py
+++ b/tests/core/test_anndata.py
@@ -33,15 +33,26 @@ from .test_base import get_adata, TestBase
 # TODO: Make more sophisticated
 class TestCleanObsNames:
     @pytest.mark.parametrize(
-        "obs_names, obs_names_cleaned",
+        "obs_names, obs_names_cleaned, id_length",
         [
             (
                 ["sample1_ABCD", "sample2_ABCD", "sample3_DCBA"],
                 ["ABCD", "ABCD-1", "DCBA"],
+                4,
             ),
             (
                 ["sample1_ABCD0815", "sample2_AMNC0707", "sample3_AAAA0902"],
                 ["ABCD", "AMNC", "AAAA"],
+                4,
+            ),
+            (
+                [
+                    "possorted_genome_bam_H66NQ:AAAGAACAGACATATGx",
+                    "possorted_genome_bam_7YCS2:AAACCCAGTCGGCTACx",
+                    "possorted_genome_bam_10UXK:AAAGGATGTGAATGATx",
+                ],
+                ["AAAGAACAGACATATG", "AAACCCAGTCGGCTAC", "AAAGGATGTGAATGAT"],
+                16,
             ),
         ],
     )
@@ -50,12 +61,13 @@ class TestCleanObsNames:
         self,
         obs_names: List[str],
         obs_names_cleaned: List[str],
+        id_length: int,
         inplace: bool,
     ):
         adata = AnnData(np.eye(3))
         adata.obs_names = obs_names
 
-        _adata = clean_obs_names(adata, inplace=inplace, id_length=4)
+        _adata = clean_obs_names(adata, inplace=inplace, id_length=id_length)
 
         if inplace:
             assert _adata is None
@@ -65,7 +77,7 @@ class TestCleanObsNames:
 
         assert (adata.obs_names == obs_names_cleaned).all()
         assert "sample_batch" in adata.obs
-        assert adata.obs["sample_batch"].str.startswith("sample").all()
+        assert adata.obs["sample_batch"].str.startswith(("sample", "possorted")).all()
 
     @pytest.mark.parametrize(
         "obs_names, obs_names_cleaned",


### PR DESCRIPTION
Switched implementation to use the previously ignored id_length
parameter. New approach finds a substring of length id_length
where each of the letters are in the alphabet

Resolves #843