### PR TITLE
Fix deprecation of keyword argument `copy`

### DIFF
--- a/scvelo/core/__init__.py
+++ b/scvelo/core/__init__.py
@@ -17,11 +17,13 @@ from ._linear_models import LinearRegression
 from ._metrics import l2_norm
 from ._models import SplicingDynamics
 from ._parallelize import get_n_jobs, parallelize
+from ._utils import deprecated_arg_names
 
 __all__ = [
     "clean_obs_names",
     "cleanup",
     "clipped_log",
+    "deprecated_arg_names",
     "get_df",
     "get_initial_size",
     "get_modality",

--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -11,10 +11,10 @@ from pandas.api.types import is_categorical_dtype
 from scipy.sparse import csr_matrix, issparse, spmatrix
 
 from anndata import AnnData
-from scanpy._utils import deprecated_arg_names
 
 from scvelo import logging as logg
 from ._arithmetic import sum
+from ._utils import deprecated_arg_names
 
 
 @deprecated_arg_names(

--- a/scvelo/core/_utils.py
+++ b/scvelo/core/_utils.py
@@ -1,0 +1,42 @@
+import warnings
+from functools import wraps
+from typing import Mapping
+
+
+# Modified from https://github.com/scverse/scanpy/blob/master/scanpy/_utils/__init__.py
+def deprecated_arg_names(arg_mapping: Mapping[str, str]):
+    """
+    Decorator which marks a functions keyword arguments as deprecated. It will
+    result in a warning being emitted when the deprecated keyword argument is
+    used, and the function being called with the new argument.
+    Parameters
+    ----------
+    arg_mapping
+        Mapping from deprecated argument name to current argument name.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def func_wrapper(*args, **kwargs):
+            warnings.simplefilter("always", DeprecationWarning)  # turn off filter
+            for old, new in arg_mapping.items():
+                if old in kwargs:
+                    warnings.warn(
+                        f"Keyword argument '{old}' has been "
+                        f"deprecated in favour of '{new}'. "
+                        f"'{old}' will be removed in a future version.",
+                        category=DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    val = kwargs.pop(old)
+                    if old == "copy":
+                        kwargs[new] = not val
+                    else:
+                        kwargs[new] = val
+            # reset filter
+            warnings.simplefilter("default", DeprecationWarning)
+            return func(*args, **kwargs)
+
+        return func_wrapper
+
+    return decorator


### PR DESCRIPTION
## New

* Add `core/_utils.py` with wrapper `deprecated_arg_names`.

## Changes

* Use local wrapper `deprecated_arg_names` instead of Scanpy version.

## Related issues
Closes #931.