### PR TITLE
Remove log advise heuristic in `preprocessing/utils.py::filter_and_normalize`

### DIFF
--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -817,20 +817,8 @@ def filter_and_normalize(
             subset=subset_highly_variable,
         )
 
-    log_advised = (
-        np.allclose(adata.X[:10].sum(), adata.layers["spliced"][:10].sum())
-        if "spliced" in adata.layers.keys()
-        else True
-    )
-
-    if log and log_advised:
+    if log:
         log1p(adata)
-    if log and log_advised:
-        logg.info("Logarithmized X.")
-    elif log and not log_advised:
-        logg.warn("Did not modify X as it looks preprocessed already.")
-    elif log_advised and not log:
-        logg.warn("Consider logarithmizing X with `scv.pp.log1p` for better results.")
 
     return adata if copy else None
 

--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -819,6 +819,7 @@ def filter_and_normalize(
 
     if log:
         log1p(adata)
+        logg.info("Logarithmized X.")
 
     return adata if copy else None
 

--- a/tests/preprocessing/test_utils.py
+++ b/tests/preprocessing/test_utils.py
@@ -627,11 +627,6 @@ class TestFilterAndNormalize:
         expected_log = "Normalized count data: X, spliced, unspliced.\n"
         if log:
             expected_log += "Logarithmized X.\n"
-        else:
-            expected_log += (
-                "WARNING: Consider logarithmizing X with `scv.pp.log1p` for better "
-                "results.\n"
-            )
 
         actual_log, _ = capfd.readouterr()
         assert actual_log == expected_log
@@ -703,11 +698,7 @@ class TestFilterAndNormalize:
         )
         if log:
             expected_log += "Logarithmized X.\n"
-        else:
-            expected_log += (
-                "WARNING: Consider logarithmizing X with `scv.pp.log1p` for better "
-                "results.\n"
-            )
+
         actual_log, _ = capfd.readouterr()
         assert actual_log == expected_log
 

--- a/tests/preprocessing/test_utils.py
+++ b/tests/preprocessing/test_utils.py
@@ -588,16 +588,15 @@ class TestFilterAndNormalize:
         filter_and_normalize(adata, log=log)
 
         assert type(adata.X) is type(original_X)
-        if issparse(original_X):
-            assert (adata.X != original_X).sum() == 0
-        else:
-            assert (adata.X == original_X).all()
+        if not log:
+            if issparse(original_X):
+                assert (adata.X != original_X).sum() == 0
+            else:
+                assert (adata.X == original_X).all()
 
         expected_log = "Normalized count data: X, spliced, unspliced.\n"
         if log:
-            expected_log += (
-                "WARNING: Did not modify X as it looks preprocessed already.\n"
-            )
+            expected_log += "Logarithmized X.\n"
 
         actual_log, _ = capfd.readouterr()
         assert actual_log == expected_log


### PR DESCRIPTION
Removes heuristic to determine if `adata.X` should be logarithmized or not.

## Changes
<!-- Please remove section if this PR does change an existing feature -->

* Removes heuristic to advise to logarithmize data or not

## Related issues
<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #959.
