### PR TITLE
Deprecate Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Changes
<!-- Please remove section if this PR does change an existing feature -->

* Remove Python 3.7 from CI runs.

## Related issues
<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #965.
