### PR TITLE
Deprecate Python 3.7 support

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,6 @@
 scanpy
 setuptools
 setuptools_scm
-typing_extensions
 importlib_metadata
 sphinx_rtd_theme>=0.3
 sphinx_autodoc_typehints<=1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-typing_extensions
-
 # main requirements for single-cell analysis
 anndata>=0.7.5        # compatible with h5py v3.0 (v0.7.5)
 scanpy>=1.5           # adapt to new anndata attributes (v1.5)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     name="scvelo",
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     install_requires=read_requirements("requirements.txt"),
     extras_require=dict(
         louvain=["python-igraph", "louvain"],


### PR DESCRIPTION
## Changes

- Remove `typing_extensions` dependency
- Update `setup.py` to require at least Python 3.8.

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Artefacts from #965.
