### PR TITLE
Deprecate Python 3.7

### DIFF
--- a/scvelo/__init__.py
+++ b/scvelo/__init__.py
@@ -28,11 +28,8 @@ try:
     __version__ = get_version(root="..", relative_to=__file__)
     del get_version
 except (LookupError, ImportError):
-    # TODO: Deprecate Python<3.8 usage.
-    try:
-        from importlib_metadata import version  # Python < 3.8
-    except ImportError:
-        from importlib.metadata import version  # Python = 3.8
+    from importlib.metadata import version
+
     __version__ = version(__name__)
     del version
 

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,6 @@ setup(
         "Intended Audience :: Science/Research",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: Bio-Informatics",


### PR DESCRIPTION
## Changes

<!-- Please remove section if this PR does change an existing feature -->

- Update `scvelo/__init__.py` to drop support for Python < 3.8.

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Artefacts of #965.
