### PR TITLE
Point rtfd to docs requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,9 @@
 build:
-    image: latest
+  image: latest
 
 python:
-    version: 3.8
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+    - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,17 @@
+version: 2
+
 build:
-    image: latest
+    os: ubuntu-20.04
+    tools:
+        python: "3.9"
+
+sphinx:
+    builder: html
+    configuration: docs/source/conf.py
+    fail_on_warning: false
 
 python:
     install:
         - method: pip
           path: .
-          extra_requirements:
-              - docs
+          extra_requirements: [docs]

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 build:
-  image: latest
+    image: latest
 
 python:
-  install:
-  - method: pip
-    path: .
-    extra_requirements:
-    - docs
+    install:
+        - method: pip
+          path: .
+          extra_requirements:
+              - docs


### PR DESCRIPTION
With moving the setup to toml, we need to point rtd to the requirements under `docs`