### PR TITLE
Added a warning message in velocity graph tool indicating that the ke…

### DIFF
--- a/scvelo/tools/velocity_graph.py
+++ b/scvelo/tools/velocity_graph.py
@@ -333,6 +333,10 @@ def velocity_graph(
     adata = data.copy() if copy else data
     verify_neighbors(adata)
     if vkey not in adata.layers.keys():
+        logg.warn(
+            f"{vkey} not found in layers\n"
+            f"Velocity is now computed using scVelo\n"
+        )
         velocity(adata, vkey=vkey)
     if sqrt_transform is None:
         sqrt_transform = variance_stabilization


### PR DESCRIPTION
Just added a warning message in velocity graph tool indicating that the velocity key is not in layers.

This is important because with the popularity of methods doing RNA velocity in lower dimensions, the velocity cannot be stored in adata.layers and it is good to show a message stating that the key was not found instead of just computing the velocity in background using scVelo.

PS: it would be a good idea to be able to decide from which part of adata structure you want to take the key (layers or obsm or anything else)