### PR TITLE
Deprecate `log1p`

### DIFF
--- a/scvelo/preprocessing/utils.py
+++ b/scvelo/preprocessing/utils.py
@@ -5,8 +5,6 @@ import pandas as pd
 from scipy.sparse import issparse
 from sklearn.utils import sparsefuncs
 
-from anndata import AnnData
-
 from scvelo import logging as logg
 from scvelo.core import get_initial_size, get_size, multiply, set_initial_size, sum
 
@@ -587,14 +585,17 @@ def log1p(data, copy=False):
     -------
     Returns or updates `adata` depending on `copy`.
     """
-    adata = data.copy() if copy else data
-    X = (
-        (adata.X.data if issparse(adata.X) else adata.X)
-        if isinstance(adata, AnnData)
-        else adata
+    warnings.warn(
+        "`log1p` is deprecated since scVelo v0.3.0 and will be removed in a "
+        "future version. Please use `log1p` from `scanpy.pp` instead.",
+        DeprecationWarning,
+        stacklevel=2,
     )
-    np.log1p(X, out=X)
-    return adata if copy else None
+
+    from scanpy.pp import log1p as scanpy_log1p
+
+    res = scanpy_log1p(data, copy=copy)
+    return res if copy else None
 
 
 def filter_and_normalize(

--- a/tests/preprocessing/test_utils.py
+++ b/tests/preprocessing/test_utils.py
@@ -2321,7 +2321,7 @@ class TestRecipeVelocity:
             )
         )
         assert pancreas_50obs.var.columns.equals(pd.Index(["gene_count_corr"]))
-        assert [*pancreas_50obs.uns] == ["pca", "neighbors"]
+        assert [*pancreas_50obs.uns] == ["log1p", "pca", "neighbors"]
         assert [*pancreas_50obs.obsm] == ["X_pca"]
         assert [*pancreas_50obs.varm] == ["PCs"]
         assert [*pancreas_50obs.layers] == ["spliced", "unspliced", "Ms", "Mu"]
@@ -2373,7 +2373,7 @@ class TestRecipeVelocity:
             )
         )
         assert dentategyrus_50obs.var.columns.equals(pd.Index([]))
-        assert [*dentategyrus_50obs.uns] == ["pca", "neighbors"]
+        assert [*dentategyrus_50obs.uns] == ["log1p", "pca", "neighbors"]
         assert [*dentategyrus_50obs.obsm] == ["X_pca"]
         assert [*dentategyrus_50obs.varm] == ["PCs"]
         assert [*dentategyrus_50obs.layers] == [


### PR DESCRIPTION
## Changes

<!-- Please remove section if this PR does change an existing feature -->

-   Deprecates `log1p` in favor of Scanpy's implementation

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #1066.
