### PR TITLE
FIX: scv.tl.rank_dynamical_genes and multidimensional array

### DIFF
--- a/scvelo/tools/_em_model_core.py
+++ b/scvelo/tools/_em_model_core.py
@@ -1149,7 +1149,7 @@ def rank_dynamical_genes(data, n_genes=100, groupby=None, copy=False):
     )
 
     idx_sorted = np.argsort(np.nan_to_num(ll), 1)[:, ::-1][:, :n_genes]
-    rankings_gene_names = vdata.var_names[idx_sorted]
+    rankings_gene_names = vdata.var_names.to_numpy()[idx_sorted]
     rankings_gene_scores = np.sort(np.nan_to_num(ll), 1)[:, ::-1][:, :n_genes]
 
     key = "rank_dynamical_genes"


### PR DESCRIPTION
## Bug fixes

This fixes a bug in `scv.tl.rank_dynamical_genes` where an attempt to slice a pandas index using a multidimensional numpy array raises a `ValueError` as that type of operation is no longer supported.  Now, the pandas index is cast to a numpy array prior to slicing.

Closes #1087
