### PR TITLE
Add release GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+on:
+    push:
+        tags: [v*]
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+        environment: pypi-release
+
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up Python 3.10
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.10"
+
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  python -m pip build
+
+            - name: Build package
+              run: |
+                  python -m build --sdist --wheel --outdir dist/
+
+            - name: Publish PyPI package
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                  skip-existing: true
+                  verify-metadata: true
+                  verbose: true


### PR DESCRIPTION
## New

Adds CI jobs to create new releases.

@WeilerP 2 things need to be done:
- [ ] creating a `pypi-release` [environment on GitHub](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment)
- [ ] adding the [trusted publisher on PyPI](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)

## Related issues

Closes #1146.