### PR TITLE
Update _anndata.py - Clarify a bug & Add Subsetting Functionality

### DIFF
--- a/scvelo/core/_anndata.py
+++ b/scvelo/core/_anndata.py
@@ -498,7 +498,8 @@ def merge(
         if id_length in kwargs:
             clean_obs_names(adata, **kwargs)
             clean_obs_names(ldata, **kwargs)
-        else raise Exception("Error. There were no matching observation names and no id_length was given to clean the observation names.")
+        else:
+            raise Exception("Error. There were no matching observation names and no id_length was given to clean the observation names.")
         common_obs = adata.obs_names.intersection(ldata.obs_names)
 
     if copy:


### PR DESCRIPTION
## Changes
The one change I wish to make relates to the error handling present in an edge case to do with merging:
- Currently, if one merges and there are no matching observations and there is no id_length given to clean the observation names, a traceback is triggered that says id_length is referenced before assignment. Since this isn't very informative of the real issue (that no id_length value was given and that there were no matching indices) I am proposing a minor change where the error is raised with a more descriptive message.

## Bug fixes

- None other than the change.

## New

Throughout my time using scvelo I really wished that it was possible to directly subset based on observations being equal to a specific value (as compared to taking entire variables), so I wrote a subset_by_value function for my own work. I think it is helpful enough to be included in the repository as a whole. 

Let me know if there is any other functionality that should be included in it and/or what tests should be run before it is merged into the main branch.

## Linked issue
https://github.com/theislab/scvelo/issues/1183