### PR TITLE
Remove hard `scvi-tools` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.9, "3.10"]
+                python-version: ["3.9", "3.10"]
         steps:
             - uses: actions/checkout@v2
             - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ dev = [
     "pybind11",
     "pytest-cov",
     "igraph",
-    "scvi-tools>=0.20.1",
     "setuptools_scm",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,13 @@ dependencies = [
     "pandas>=1.1.1, !=1.4.0",
     "scipy>=1.4.1",
     "scikit-learn>=0.21.2, <1.2.0",
-    "scvi-tools>=0.20.1",
     "matplotlib>=3.3.0"
 ]
 
 [project.optional-dependencies]
+vi = [
+    "scvi-tools>=0.20.1",
+]
 louvain = [
     "igraph",
     "louvain"
@@ -78,7 +80,8 @@ dev = [
     "pybind11",
     "pytest-cov",
     "igraph",
-    "setuptools_scm"
+    "scvi-tools>=0.20.1",
+    "setuptools_scm",
 ]
 docs = [
     # Just until rtd.org understands pyproject.toml

--- a/scvelo/tools/__init__.py
+++ b/scvelo/tools/__init__.py
@@ -1,3 +1,5 @@
+import contextlib
+
 from scanpy.tools import diffmap, dpt, louvain, tsne, umap
 
 from ._em_model import ExpectationMaximizationModel
@@ -11,7 +13,6 @@ from ._em_model_core import (
     recover_latent_time,
 )
 from ._steady_state_model import SecondOrderSteadyStateModel, SteadyStateModel
-from ._vi_model import VELOVI
 from .paga import paga
 from .rank_velocity_genes import rank_velocity_genes, velocity_clusters
 from .score_genes_cell_cycle import score_genes_cell_cycle
@@ -22,6 +23,10 @@ from .velocity_confidence import velocity_confidence, velocity_confidence_transi
 from .velocity_embedding import velocity_embedding
 from .velocity_graph import velocity_graph
 from .velocity_pseudotime import velocity_map, velocity_pseudotime
+
+with contextlib.suppress(ImportError):
+    from ._vi_model import VELOVI
+
 
 __all__ = [
     "align_dynamics",
@@ -54,5 +59,8 @@ __all__ = [
     "SteadyStateModel",
     "SecondOrderSteadyStateModel",
     "ExpectationMaximizationModel",
-    "VELOVI",
 ]
+if "VELOVI" in locals():
+    __all__ += ["VELOVI"]
+
+del contextlib

--- a/scvelo/tools/_core.py
+++ b/scvelo/tools/_core.py
@@ -1,8 +1,6 @@
 from abc import abstractmethod
 from typing import NamedTuple
 
-import torch
-
 from anndata import AnnData
 
 
@@ -12,8 +10,6 @@ class _REGISTRY_KEYS_NT(NamedTuple):
 
 
 REGISTRY_KEYS = _REGISTRY_KEYS_NT()
-
-DEFAULT_ACTIVATION_FUNCTION = torch.nn.Softplus()
 
 
 class BaseInference:

--- a/scvelo/tools/_vi_module.py
+++ b/scvelo/tools/_vi_module.py
@@ -11,7 +11,9 @@ from torch.distributions import MixtureSameFamily, Normal
 from scvi.module.base import auto_move_data, BaseModuleClass, LossOutput
 from scvi.nn import Encoder, FCLayers
 
-from ._core import DEFAULT_ACTIVATION_FUNCTION, REGISTRY_KEYS
+from ._core import REGISTRY_KEYS
+
+DEFAULT_ACTIVATION_FUNCTION = torch.nn.Softplus()
 
 torch.backends.cudnn.benchmark = True
 

--- a/tests/tools/test_vi_model.py
+++ b/tests/tools/test_vi_model.py
@@ -1,7 +1,15 @@
-from scvi.data import synthetic_iid
+# isort: skip_file
+import pytest
+import contextlib
 
 import scvelo as scv
-from scvelo.tools import VELOVI
+
+with contextlib.suppress(ImportError):
+    from scvi.data import synthetic_iid
+    from scvelo.tools import VELOVI
+
+
+_ = pytest.importorskip("scvi")
 
 
 def test_preprocess_data():

--- a/tests/tools/test_vi_model.py
+++ b/tests/tools/test_vi_model.py
@@ -1,11 +1,12 @@
-# isort: skip_file
-import pytest
 import contextlib
+
+import pytest
 
 import scvelo as scv
 
 with contextlib.suppress(ImportError):
     from scvi.data import synthetic_iid
+
     from scvelo.tools import VELOVI
 
 


### PR DESCRIPTION
## Changes

<!-- Please remove section if this PR does change an existing feature -->

Make `scvi-tools` install optional as `pip install 'scvelo[vi]'`.

Related to the failing CI, see here: https://github.com/theislab/cellrank/pull/1156#issuecomment-1932823547

## Related issues

Closes #1189.