### PR TITLE
Fix/compute_neighbors, issue #1212

### DIFF
--- a/scvelo/preprocessing/neighbors.py
+++ b/scvelo/preprocessing/neighbors.py
@@ -37,7 +37,7 @@ def _get_scanpy_neighbors(adata: AnnData, **kwargs):
     with warnings.catch_warnings():  # ignore numba warning (umap/issues/252)
         warnings.simplefilter("ignore")
         neighbors = Neighbors(adata)
-        neighbors.compute_neighbors(write_knn_indices=True, **kwargs)
+        neighbors.compute_neighbors(**kwargs)
     logg.switch_verbosity("on", module="scanpy")
 
     return neighbors


### PR DESCRIPTION
#1212 
scv.pp.moments(adata, n_pcs= int , n_neighbors= int )

Returns: 
TypeError: Neighbors.compute_neighbors() got an unexpected keyword argument 'write_knn_indices'

The argument write_knn_indices was deprecated in a previous commit (see [scanpy commit 1fd6c46](https://github.com/scverse/scanpy/commit/1fd6c46997b95ef837a8dd2561888656c8fa7bdd)) 

Removing 'write_knn_indices' arg from the compute_neighbors method call within scv.pp.moments does not seem to affect downstream analysis
Lmk what you think @WeilerP 