### PR TITLE
Remove numpy<2.0.0 pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "loompy>=2.0.12",
     "umap-learn>=0.3.10",
     "numba>=0.41.0",
-    "numpy>=1.17, <2.0.0",
+    "numpy>=1.17",
     "pandas>=1.1.1, !=1.4.0",
     "scipy>=1.4.1",
     "scikit-learn>=0.21.2",


### PR DESCRIPTION
## Changes

<!-- Please remove section if this PR does change an existing feature -->

- Unpins upper version of numpy.
