### PR TITLE
Implement fix of get_sparse_from_igraph() theislab/scvelo#1241

### DIFF
--- a/scvelo/tools/paga.py
+++ b/scvelo/tools/paga.py
@@ -48,7 +48,8 @@ def get_sparse_from_igraph(graph, weight_attr=None):
     shape = graph.vcount()
     shape = (shape, shape)
     if len(edges) > 0:
-        return csr_matrix((weights, zip(*edges)), shape=shape)
+        rows, cols = zip(*edges)
+        return csr_matrix((weights, (rows, cols)), shape=shape)
     else:
         return csr_matrix(shape)
 


### PR DESCRIPTION
## Bug fixes

-   Fixes bug that results in `ValueError: mismatching number of index arrays for shape; got 0, expected 2` when running `scv.tl.paga`


## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #1241 
